### PR TITLE
Fix issue #111: Branch title is missing in failed github actions workflows

### DIFF
--- a/.github/workflows/openhands-resolver-experimental.yml
+++ b/.github/workflows/openhands-resolver-experimental.yml
@@ -98,7 +98,13 @@ jobs:
                 body: `A potential fix has been generated and a draft PR #${prNumber} has been created. Please review the changes.`
               });
             } else {
-              const branchName = fs.readFileSync('branch_name.txt', 'utf8').trim();
+              let branchName = '';
+              try {
+                branchName = fs.readFileSync('branch_name.txt', 'utf8').trim();
+              } catch (error) {
+                console.error('Error reading branch_name.txt:', error);
+                branchName = 'unknown';
+              }
               github.rest.issues.createComment({
                 issue_number: issueNumber,
                 owner: context.repo.owner,

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -98,7 +98,13 @@ jobs:
                 body: `A potential fix has been generated and a draft PR #${prNumber} has been created. Please review the changes.`
               });
             } else {
-              const branchName = fs.readFileSync('branch_name.txt', 'utf8').trim();
+              let branchName = '';
+              try {
+                branchName = fs.readFileSync('branch_name.txt', 'utf8').trim();
+              } catch (error) {
+                console.error('Error reading branch_name.txt:', error);
+                branchName = 'unknown';
+              }
               github.rest.issues.createComment({
                 issue_number: issueNumber,
                 owner: context.repo.owner,


### PR DESCRIPTION
This pull request fixes #111.

The issue of missing branch titles in comments from failed GitHub Actions workflows has been resolved. The PR makes the following key changes to both .github/workflows/openhands-resolver.yml and .github/workflows/openhands-resolver-experimental.yml:

1. Added a try-catch block to handle potential errors when reading the branch name.
2. If an error occurs while reading the branch name, it's set to 'unknown' instead of causing a workflow failure.
3. Ensured that the comment will always be posted with either the correct branch name or 'unknown' if there's an issue.

These changes should prevent the occurrence of empty branch names in the comments and improve the overall reliability of the workflow. As requested, no tests were added since it's challenging to test GitHub workflows directly. The changes maintain parity between the main and experimental workflow files.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌