### PR TITLE
Fix issue #111: Branch title is missing in failed github actions workflows

### DIFF
--- a/.github/workflows/openhands-resolver-experimental.yml
+++ b/.github/workflows/openhands-resolver-experimental.yml
@@ -77,7 +77,7 @@ jobs:
               --issue-number ${{ github.event.issue.number }} \
               --pr-type branch \
               --send-on-failure | tee branch_result.txt && \
-              grep "Branch" branch_result.txt | sed 's/.*\///g; s/.expand=1//g' > branch_name.txt
+              grep "Branch" branch_result.txt | sed -E 's/.*Branch ([^ ]+).*/\1/' > branch_name.txt
           fi
 
       - name: Comment on issue

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -77,7 +77,7 @@ jobs:
               --issue-number ${{ github.event.issue.number }} \
               --pr-type branch \
               --send-on-failure | tee branch_result.txt && \
-              grep "Branch" branch_result.txt | sed 's/.*\///g; s/.expand=1//g' > branch_name.txt
+              grep "Branch" branch_result.txt | sed -E 's/.*Branch ([^ ]+).*/\1/' > branch_name.txt
           fi
 
       - name: Comment on issue


### PR DESCRIPTION
This pull request fixes #111.

The issue has been successfully resolved by updating the branch name extraction command in both '.github/workflows/openhands-resolver.yml' and '.github/workflows/openhands-resolver-experimental.yml'. The new command uses grep and sed to correctly extract the branch name from the output of the openhands_resolver.send_pull_request command. This should fix the problem of missing branch titles in comments from failed GitHub Actions workflows. The changes were applied to both workflow files to maintain parity. No tests were required as per the issue description. These modifications should now correctly capture and include the branch name in the comment when a fix attempt is unsuccessful.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌