### PR TITLE
Fix issue #117: Better error handling after `Create draft PR or push branch` workflow

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -89,20 +89,38 @@ jobs:
             const issueNumber = context.issue.number;
             const success = ${{ steps.check_result.outputs.RESOLUTION_SUCCESS }};
             
-            if (success) {
-              const prNumber = fs.readFileSync('pr_number.txt', 'utf8').trim();
+            let prNumber = '';
+            let branchName = '';
+            
+            try {
+              if (success) {
+                prNumber = fs.readFileSync('pr_number.txt', 'utf8').trim();
+              } else {
+                branchName = fs.readFileSync('branch_name.txt', 'utf8').trim();
+              }
+            } catch (error) {
+              console.error('Error reading file:', error);
+            }
+            
+            if (success && prNumber) {
               github.rest.issues.createComment({
                 issue_number: issueNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: `A potential fix has been generated and a draft PR #${prNumber} has been created. Please review the changes.`
               });
-            } else {
-              const branchName = fs.readFileSync('branch_name.txt', 'utf8').trim();
+            } else if (!success && branchName) {
               github.rest.issues.createComment({
                 issue_number: issueNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: `An attempt was made to automatically fix this issue, but it was unsuccessful. A branch named '${branchName}' has been created with the attempted changes. You can view the branch [here](https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${branchName}). Manual intervention may be required.`
+              });
+            } else {
+              github.rest.issues.createComment({
+                issue_number: issueNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `The workflow to fix this issue encountered an error. Please check the workflow logs for more information.`
               });
             }


### PR DESCRIPTION
This pull request fixes #117.

The issue has been successfully resolved. The workflow has been updated to check for non-empty values in `prNumber` or `branchName` before posting a comment about successful branch creation or PR opening. Additionally, an error message is now included if the workflow fails. This prevents the incorrect posting of success messages when the workflow fails due to permission issues or other problems. As this is a GitHub workflow change, no Python tests were needed. The changes directly address the described issue and should improve the accuracy of the workflow's feedback.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌