### PR TITLE
Fix issue #139: Allow specification of `--fork-owner` in github workflow

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -74,17 +74,24 @@ jobs:
           LLM_MODEL: ${{ secrets.LLM_MODEL }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+          PAT_FORK_OWNER: ${{ secrets.PAT_FORK_OWNER }}
         run: |
+          FORK_OWNER_ARG=""
+          if [ -n "$PAT_FORK_OWNER" ]; then
+            FORK_OWNER_ARG="--fork-owner $PAT_FORK_OWNER"
+          fi
           if [ "${{ steps.check_result.outputs.RESOLUTION_SUCCESS }}" == "true" ]; then
             python -m openhands_resolver.send_pull_request \
               --issue-number ${{ env.ISSUE_NUMBER }} \
-              --pr-type draft | tee pr_result.txt && \
+              --pr-type draft \
+              $FORK_OWNER_ARG | tee pr_result.txt && \
               grep "draft created" pr_result.txt | sed 's/.*\///g' > pr_number.txt
           else
             python -m openhands_resolver.send_pull_request \
               --issue-number ${{ env.ISSUE_NUMBER }} \
               --pr-type branch \
-              --send-on-failure | tee branch_result.txt && \
+              --send-on-failure \
+              $FORK_OWNER_ARG | tee branch_result.txt && \
               grep "branch created" branch_result.txt | sed 's/.*\///g; s/.expand=1//g' > branch_name.txt
           fi
 


### PR DESCRIPTION
This pull request fixes #139.

This PR successfully addresses the issue by modifying the GitHub workflow file (.github/workflows/openhands-resolver.yml) to support setting the fork owner when creating pull requests. The following changes were implemented:

1. Added a new environment variable 'PAT_FORK_OWNER' to the workflow, which can be set using GitHub secrets.
2. Introduced logic to create a 'FORK_OWNER_ARG' based on the presence of 'PAT_FORK_OWNER'.
3. Updated the 'send_pull_request.py' command in the workflow to include the 'FORK_OWNER_ARG' when executing.

These changes allow the workflow to use the '--fork-owner' argument when 'PAT_FORK_OWNER' is set, enabling the creation of pull requests for non-owned repositories. This implementation provides the requested functionality while maintaining flexibility for cases where the fork owner doesn't need to be specified.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌