### PR TITLE
Fix secrets passing

### DIFF
--- a/examples/openhands-resolver.yml
+++ b/examples/openhands-resolver.yml
@@ -10,4 +10,10 @@ jobs:
     if: github.event.label.name == 'fix-me'
     with:
       issue_number: ${{ github.event.issue.number }}
-    secrets: inherit
+    secrets:
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      PAT_USERNAME: ${{ secrets.PAT_USERNAME }}
+      PAT_FORK_OWNER: ${{ secrets.PAT_FORK_OWNER }}
+      LLM_MODEL: ${{ secrets.LLM_MODEL }}
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}


### PR DESCRIPTION
Previously, the OpenHands resolver action didn't work when installed on an organization other than all-hands-ai because the [secrets: inherit does not work across organizations](https://github.com/orgs/community/discussions/23107#discussioncomment-3239168).

This PR fixes the issue by not using `secrets: inherit` and just passing the secrets explicitly.

Fixes #144 