### PR TITLE
Refactoring "if" statements switching between "issue" and "PR" issue-types 

### DIFF
--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -1,0 +1,347 @@
+import re
+from abc import ABC, abstractmethod
+from typing import ClassVar, Any
+import requests
+import litellm
+import jinja2
+import json
+
+from openhands.memory.history import ShortTermHistory
+from openhands_resolver.github_issue import GithubIssue
+from openhands.core.config import LLMConfig
+from openhands.core.logger import openhands_logger as logger
+
+
+
+class IssueHandlerInterface(ABC):
+    issue_type: ClassVar[str]
+    
+    @abstractmethod
+    def get_converted_issues(self) -> list[GithubIssue]:
+        """Download issues from GitHub."""
+        pass
+    
+    @abstractmethod
+    def get_instruction(self, issue: GithubIssue, prompt_template: str, repo_instruction: str | None = None) -> str:
+        """Generate instruction for the agent."""
+        pass
+    
+    @abstractmethod
+    def guess_success(self, issue: GithubIssue, history: ShortTermHistory, llm_config: LLMConfig) -> tuple[bool, list[bool] | None, str]:
+        """Guess if the issue has been resolved based on the agent's output."""
+        pass
+
+
+
+    
+class IssueHandler(IssueHandlerInterface):
+    issue_type: ClassVar[str] = "issue"
+
+    def __init__(self, owner: str, repo: str, token: str):
+        self.download_url = "https://api.github.com/repos/{}/{}/issues"
+        self.owner = owner
+        self.repo = repo
+        self.token = token
+    
+    def _download_issues_from_github(self) -> list[Any]:
+        url = self.download_url.format(self.owner, self.repo)
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github.v3+json",
+        }
+        params: dict[str, int | str] = {"state": "open", "per_page": 100, "page": 1}
+        all_issues = []
+
+        while True:
+            response = requests.get(url, headers=headers, params=params)
+            response.raise_for_status()
+            issues = response.json()
+
+            if not issues:
+                break
+
+            if not isinstance(issues, list) or any(
+                [not isinstance(issue, dict) for issue in issues]
+            ):
+                raise ValueError("Expected list of dictionaries from Github API.")
+
+            all_issues.extend(issues)
+            assert isinstance(params["page"], int)
+            params["page"] += 1
+
+        return all_issues
+    
+    def get_converted_issues(self) -> list[GithubIssue]:
+        """Download issues from Github.
+
+        Returns:
+            List of Github issues.
+        """
+         
+        all_issues = self._download_issues_from_github()
+        converted_issues = []
+        for issue in all_issues:
+            if any([issue.get(key) is None for key in ["number", "title", "body"]]):
+                logger.warning(
+                    f"Skipping issue {issue} as it is missing number, title, or body."
+                )
+                continue
+
+            if "pull_request" in issue:
+                continue
+            
+            issue_details = GithubIssue(
+                                owner=self.owner,
+                                repo=self.repo,
+                                number=issue["number"],
+                                title=issue["title"],
+                                body=issue["body"],
+                            )
+                
+            converted_issues.append(issue_details)
+        return converted_issues
+
+        
+    def get_instruction(self, issue: GithubIssue, prompt_template: str, repo_instruction: str | None = None) -> str:
+        """Generate instruction for the agent"""
+        template = jinja2.Template(prompt_template)
+        return template.render(body=issue.body, repo_instruction=repo_instruction)
+
+    def guess_success(self, issue: GithubIssue, history: ShortTermHistory, llm_config: LLMConfig) -> tuple[bool, None | list[bool], str]:
+        """Guess if the issue is fixed based on the history and the issue description."""
+       
+        last_message = history.get_events_as_list()[-1].message    
+        prompt = f"""Given the following issue description and the last message from an AI agent attempting to fix it, determine if the issue has been successfully resolved.
+
+        Issue description:
+        {issue.body}
+
+        Last message from AI agent:
+        {last_message}
+
+        (1) has the issue been successfully resolved?
+        (2) If the issue has been resolved, please provide an explanation of what was done in the PR that can be sent to a human reviewer on github. If the issue has not been resolved, please provide an explanation of why.
+
+        Answer in exactly the format below, with only true or false for success, and an explanation of the result.
+
+        --- success
+        true/false
+
+        --- explanation
+        ...
+        """
+
+        response = litellm.completion(
+            model=llm_config.model,
+            messages=[{"role": "user", "content": prompt}],
+            api_key=llm_config.api_key,
+            base_url=llm_config.base_url,
+        )
+        
+        answer = response.choices[0].message.content.strip()
+        pattern = r'--- success\n*(true|false)\n*--- explanation*\n(.*)'
+        match = re.search(pattern, answer)
+        if match:
+            return match.group(1).lower() == 'true', None, match.group(2)
+        
+        return False, None, f"Failed to decode answer from LLM response: {answer}"
+
+
+
+class PRHandler(IssueHandler):
+    issue_type: ClassVar[str] = "pr"
+
+    def __init__(self, owner: str, repo: str, token: str):
+        super().__init__(owner, repo, token)
+        self.download_url = "https://api.github.com/repos/{}/{}/pulls"
+
+
+
+    def __download_pr_metadata(self, pull_number: int):
+    
+        """
+            Run a GraphQL query against the GitHub API for information on 
+                1. unresolved review comments
+                2. referenced issues the pull request would close
+
+            Args:
+                query: The GraphQL query as a string.
+                variables: A dictionary of variables for the query.
+                token: Your GitHub personal access token.
+
+            Returns:
+                The JSON response from the GitHub API.
+        """
+        # Using graphql as REST API doesn't indicate resolved status for review comments
+        # TODO: grabbing the first 10 issues, 100 review threads, and 100 coments; add pagination to retrieve all
+        query = """
+                query($owner: String!, $repo: String!, $pr: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                        pullRequest(number: $pr) {
+                            closingIssuesReferences(first: 10) {
+                                edges {
+                                    node {
+                                        body
+                                    }
+                                }
+                            }
+                            url
+                            reviewThreads(first: 100) {
+                                edges{
+                                    node{
+                                        isResolved
+                                        comments(first: 100) {
+                                            totalCount
+                                            nodes {
+                                                body
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            """
+
+
+
+        variables = {
+            "owner": self.owner,
+            "repo": self.repo,
+            "pr": pull_number
+        }
+
+        url = "https://api.github.com/graphql"
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json"
+        }
+        
+        response = requests.post(url, json={"query": query, "variables": variables}, headers=headers)
+        response.raise_for_status()
+        response_json = response.json()
+
+        # Parse the response to get closing issue references and unresolved review comments
+        pr_data = response_json.get("data", {}).get("repository", {}).get("pullRequest", {})
+
+        # Get closing issues
+        closing_issues = pr_data.get("closingIssuesReferences", {}).get("edges", [])
+        closing_issues_bodies = [issue["node"]["body"] for issue in closing_issues]
+
+        # Get unresolved review comments
+        unresolved_comments = []
+        review_threads = pr_data.get("reviewThreads", {}).get("edges", [])
+        for thread in review_threads:
+            node = thread.get("node", {})
+            if not node.get("isResolved", True):  # Check if the review thread is unresolved
+                comments = node.get("comments", {}).get("nodes", [])
+                message = ""
+                for i, comment in enumerate(comments):
+                    if i == len(comments) - 1:  # Check if it's the last comment in the thread
+                        if len(comments) > 1:
+                            message += "---\n"  # Add "---" before the last message if there's more than one comment
+                        message += "latest feedback:\n" + comment["body"] + "\n"
+                    else:
+                        message += comment["body"] + "\n"  # Add each comment in a new line
+                unresolved_comments.append(message)
+
+        return closing_issues_bodies, unresolved_comments
+
+
+    # Override processing of downloaded issues
+    def get_converted_issues(self) -> list[GithubIssue]:
+        all_issues = self._download_issues_from_github()
+        converted_issues = []
+        for issue in all_issues:
+            if any([issue.get(key) is None for key in ["number", "title", "body"]]):
+                logger.warning(
+                    f"Skipping issue {issue} as it is missing number, title, or body."
+                )
+                continue            
+
+            closing_issues, unresolved_comments = self.__download_pr_metadata(issue["number"])
+            head_branch = issue["head"]["ref"]
+            issue_details = GithubIssue(
+                                owner=self.owner,
+                                repo=self.repo,
+                                number=issue["number"],
+                                title=issue["title"],
+                                body=issue["body"],
+                                closing_issues=closing_issues,
+                                review_comments=unresolved_comments,
+                                head_branch=head_branch
+                            )
+            
+            converted_issues.append(issue_details)
+
+        return converted_issues
+
+
+    def get_instruction(self, issue: GithubIssue, prompt_template: str, repo_instruction: str | None = None) -> str:
+        """Generate instruction for the agent"""
+        template = jinja2.Template(prompt_template)
+
+        if issue.closing_issues is None or issue.review_comments is None:
+            raise ValueError("issue.closing_issues or issue.review_comments is None")
+        issues_context = json.dumps(issue.closing_issues, indent=4)
+        comment_chain = json.dumps(issue.review_comments, indent=4)
+        instruction = template.render(issues=issues_context, body=comment_chain, repo_instruction=repo_instruction)
+        return instruction
+    
+
+    def guess_success(self, issue: GithubIssue, history: ShortTermHistory, llm_config: LLMConfig) -> tuple[bool, None | list[bool], str]:
+        """Guess if the issue is fixed based on the history and the issue description."""
+        
+        last_message = history.get_events_as_list()[-1].message
+        issues_context = json.dumps(issue.closing_issues, indent=4)
+        success_list = []
+        explanation_list = []
+
+        if issue.review_comments:
+            for comment in issue.review_comments:
+                formatted_comment = json.dumps(comment, indent=4)
+                prompt = f"""You are given one or more issue descriptions, a piece of feedback to resolve the issues, and the last message from an AI agent attempting to incorporate the feedback. Determine if the feedback has been successfully resolved.
+                
+                Issue descriptions:
+                {issues_context}
+
+                Feedback:
+                {formatted_comment}
+
+                Last message from AI agent:
+                {last_message}
+
+                (1) has the feedback been successfully incorporated?
+                (2) If the feebdack has been incorporated, please provide an explanation of what was done that can be sent to a human reviewer on github. If the feedback has not been resolved, please provide an explanation of why.
+
+                Answer in exactly the format below, with only true or false for success, and an explanation of the result.
+
+                --- success
+                true/false
+
+                --- explanation
+                ...
+                """
+
+                response = litellm.completion(
+                    model=llm_config.model,
+                    messages=[{"role": "user", "content": prompt}],
+                    api_key=llm_config.api_key,
+                    base_url=llm_config.base_url,
+                )
+            
+                answer = response.choices[0].message.content.strip()
+                pattern = r'--- success\n*(true|false)\n*--- explanation*\n(.*)'
+                match = re.search(pattern, answer)
+                if match:
+                    success_list.append(match.group(1).lower() == 'true')
+                    explanation_list.append(match.group(2))
+                else:
+                    success_list.append(False)
+                    f"Failed to decode answer from LLM response: {answer}"
+        else:
+            raise ValueError("Expected review comments to be initialized.")
+        
+        success = all(success_list)
+        return success, success_list, json.dumps(explanation_list)

--- a/openhands_resolver/resolve_issues.py
+++ b/openhands_resolver/resolve_issues.py
@@ -2,17 +2,13 @@
 
 import asyncio
 import dataclasses
-import re
 import shutil
 from typing import Any, Awaitable, TextIO
-import requests
 import argparse
-import litellm
 import multiprocessing as mp
 import os
 import pathlib
 import subprocess
-import jinja2
 import json
 
 from termcolor import colored
@@ -20,13 +16,17 @@ from tqdm import tqdm
 
 
 from openhands_resolver.github_issue import GithubIssue
+from openhands_resolver.issue_definitions import ( 
+    IssueHandler, 
+    IssueHandlerInterface, 
+    PRHandler
+)
 from openhands_resolver.resolver_output import ResolverOutput
 import openhands
 from openhands.core.main import create_runtime, run_controller
 from openhands.controller.state.state import State
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action import CmdRunAction
-from openhands.memory.history import ShortTermHistory
 from openhands.events.observation import (
     CmdOutputObservation,
     ErrorObservation,
@@ -193,122 +193,6 @@ async def complete_runtime(
     logger.info('END Runtime Completion Fn')
     logger.info('-' * 30)
     return {'git_patch': git_patch}
-
-
-def get_instruction(
-    issue: GithubIssue,
-    prompt_template: str,
-    issue_type: str,
-    repo_instruction: str | None = None,
-):  # Prepare instruction
-    template = jinja2.Template(prompt_template)
-    if issue_type == "issue":
-        instruction = template.render(body=issue.body, repo_instruction=repo_instruction)
-    elif issue_type == "pr":
-        if issue.closing_issues is None or issue.review_comments is None:
-            raise ValueError("issue.closing_issues or issue.review_comments is None")
-        issues_context = json.dumps(issue.closing_issues, indent=4)
-        comment_chain = json.dumps(issue.review_comments, indent=4)
-        instruction = template.render(issues=issues_context, body=comment_chain, repo_instruction=repo_instruction)
-    else:
-        raise ValueError(f"Invalid issue type {issue_type}")
-
-    return instruction
-
-
-def guess_success(issue: GithubIssue, issue_type: str, history: ShortTermHistory, llm_config: LLMConfig) -> tuple[bool, None | list[bool], str]:
-    """Guess if the issue is fixed based on the history and the issue description."""
-    
-    last_message = history.get_events_as_list()[-1].message
-    if issue_type == "issue":
-    
-        prompt = f"""Given the following issue description and the last message from an AI agent attempting to fix it, determine if the issue has been successfully resolved.
-
-        Issue description:
-        {issue.body}
-
-        Last message from AI agent:
-        {last_message}
-
-        (1) has the issue been successfully resolved?
-        (2) If the issue has been resolved, please provide an explanation of what was done in the PR that can be sent to a human reviewer on github. If the issue has not been resolved, please provide an explanation of why.
-
-        Answer in exactly the format below, with only true or false for success, and an explanation of the result.
-
-        --- success
-        true/false
-
-        --- explanation
-        ...
-        """
-
-        response = litellm.completion(
-            model=llm_config.model,
-            messages=[{"role": "user", "content": prompt}],
-            api_key=llm_config.api_key,
-            base_url=llm_config.base_url,
-        )
-        
-        answer = response.choices[0].message.content.strip()
-        pattern = r'--- success\n*(true|false)\n*--- explanation*\n(.*)'
-        match = re.search(pattern, answer)
-        if match:
-            return match.group(1).lower() == 'true', None, match.group(2)
-        
-        return False, None, f"Failed to decode answer from LLM response: {answer}"
-    else:
-        issues_context = json.dumps(issue.closing_issues, indent=4)
-        success_list = []
-        explanation_list = []
-
-        if issue.review_comments:
-            for comment in issue.review_comments:
-                formatted_comment = json.dumps(comment, indent=4)
-                prompt = f"""You are given one or more issue descriptions, a piece of feedback to resolve the issues, and the last message from an AI agent attempting to incorporate the feedback. Determine if the feedback has been successfully resolved.
-                
-                Issue descriptions:
-                {issues_context}
-
-                Feedback:
-                {formatted_comment}
-
-                Last message from AI agent:
-                {last_message}
-
-                (1) has the feedback been successfully incorporated?
-                (2) If the feebdack has been incorporated, please provide an explanation of what was done that can be sent to a human reviewer on github. If the feedback has not been resolved, please provide an explanation of why.
-
-                Answer in exactly the format below, with only true or false for success, and an explanation of the result.
-
-                --- success
-                true/false
-
-                --- explanation
-                ...
-                """
-
-                response = litellm.completion(
-                    model=llm_config.model,
-                    messages=[{"role": "user", "content": prompt}],
-                    api_key=llm_config.api_key,
-                    base_url=llm_config.base_url,
-                )
-            
-                answer = response.choices[0].message.content.strip()
-                pattern = r'--- success\n*(true|false)\n*--- explanation*\n(.*)'
-                match = re.search(pattern, answer)
-                if match:
-                    success_list.append(match.group(1).lower() == 'true')
-                    explanation_list.append(match.group(2))
-                else:
-                    success_list.append(False)
-                    f"Failed to decode answer from LLM response: {answer}"
-        else:
-            raise ValueError("Expected review comments to be initialized.")
-        
-        success = all(success_list)
-        return success, success_list, json.dumps(explanation_list)
-            
         
 
 async def process_issue(
@@ -319,7 +203,7 @@ async def process_issue(
     output_dir: str,
     runtime_container_image: str,
     prompt_template: str,
-    issue_type: str,
+    issue_handler: IssueHandlerInterface,
     repo_instruction: str | None = None,
     reset_logger: bool = True,
 ) -> ResolverOutput:
@@ -331,7 +215,7 @@ async def process_issue(
     else:
         logger.info(f'Starting fixing issue {issue.number}.')
 
-    workspace_base = os.path.join(output_dir, "workspace", f"{issue_type}_{issue.number}")
+    workspace_base = os.path.join(output_dir, "workspace", f"{issue_handler.issue_type}_{issue.number}")
 
     # Get the absolute path of the workspace base
     workspace_base = os.path.abspath(workspace_base)
@@ -361,7 +245,7 @@ async def process_issue(
     runtime = create_runtime(config, sid=f"{issue.number}")
     initialize_runtime(runtime)
 
-    instruction = get_instruction(issue, prompt_template, issue_type, repo_instruction)
+    instruction = issue_handler.get_instruction(issue, prompt_template, repo_instruction)
 
     # Here's how you can run the agent (similar to the `main` function) and get the final task state
     state: State | None = await run_controller(
@@ -385,9 +269,9 @@ async def process_issue(
     metrics = state.metrics.get() if state.metrics else None
 
     # determine success based on the history and the issue description
-    success, comment_success, success_explanation = guess_success(issue, issue_type, state.history, llm_config)
+    success, comment_success, success_explanation = issue_handler.guess_success(issue, state.history, llm_config)
 
-    if issue_type == "pr" and comment_success:
+    if issue_handler.issue_type == "pr" and comment_success:
         success_log = "I have updated the PR and resolved some of the issues that were cited in the pull request review. Specifically, I identified the following revision requests, and all the ones that I think I successfully resolved are checked off. All the unchecked ones I was not able to resolve, so manual intervention may be required:\n"
         for success_indicator, explanation in zip(comment_success, json.loads(success_explanation)):
                 status = colored("[X]", "red") if success_indicator else colored("[ ]", "red")
@@ -400,7 +284,7 @@ async def process_issue(
     # Save the output
     output = ResolverOutput(
         issue=issue,
-        issue_type=issue_type,
+        issue_type=issue_handler.issue_type,
         instruction=instruction,
         base_commit=base_commit,
         git_patch=git_patch,
@@ -412,184 +296,6 @@ async def process_issue(
         error=state.last_error if state and state.last_error else None,
     )
     return output
-
-def download_pr_metadata(owner: str, repo: str, token: str, pull_number: int):
-    
-    """
-        Run a GraphQL query against the GitHub API for information on 
-            1. unresolved review comments
-            2. referenced issues the pull request would close
-
-        Args:
-            query: The GraphQL query as a string.
-            variables: A dictionary of variables for the query.
-            token: Your GitHub personal access token.
-
-        Returns:
-            The JSON response from the GitHub API.
-    """
-    # Using graphql as REST API doesn't indicate resolved status for review comments
-    # TODO: grabbing the first 10 issues, 100 review threads, and 100 coments; add pagination to retrieve all
-    query = """
-            query($owner: String!, $repo: String!, $pr: Int!) {
-                repository(owner: $owner, name: $repo) {
-                    pullRequest(number: $pr) {
-                        closingIssuesReferences(first: 10) {
-                            edges {
-                                node {
-                                    body
-                                }
-                            }
-                        }
-                        url
-                        reviewThreads(first: 100) {
-                            edges{
-                                node{
-                                    isResolved
-                                    comments(first: 100) {
-                                        totalCount
-                                        nodes {
-                                            body
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        """
-
-
-
-    variables = {
-        "owner": owner,
-        "repo": repo,
-        "pr": pull_number
-    }
-
-    url = "https://api.github.com/graphql"
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json"
-    }
-    
-    response = requests.post(url, json={"query": query, "variables": variables}, headers=headers)
-    response.raise_for_status()
-    response_json = response.json()
-
-    # Parse the response to get closing issue references and unresolved review comments
-    pr_data = response_json.get("data", {}).get("repository", {}).get("pullRequest", {})
-
-    # Get closing issues
-    closing_issues = pr_data.get("closingIssuesReferences", {}).get("edges", [])
-    closing_issues_bodies = [issue["node"]["body"] for issue in closing_issues]
-
-    # Get unresolved review comments
-    unresolved_comments = []
-    review_threads = pr_data.get("reviewThreads", {}).get("edges", [])
-    for thread in review_threads:
-        node = thread.get("node", {})
-        if not node.get("isResolved", True):  # Check if the review thread is unresolved
-            comments = node.get("comments", {}).get("nodes", [])
-            message = ""
-            for i, comment in enumerate(comments):
-                if i == len(comments) - 1:  # Check if it's the last comment in the thread
-                    if len(comments) > 1:
-                        message += "---\n"  # Add "---" before the last message if there's more than one comment
-                    message += "latest feedback:\n" + comment["body"] + "\n"
-                else:
-                    message += comment["body"] + "\n"  # Add each comment in a new line
-            unresolved_comments.append(message)
-
-    return closing_issues_bodies, unresolved_comments
-
-
-
-def download_issues_from_github(
-    owner: str, repo: str, token: str, issue_type: str
-) -> list[GithubIssue]:
-    """Download issues from Github.
-
-    Args:
-        owner: Owner of the github repo
-        repo: Github repository to resolve issues.
-        token: Github token to access the repository.
-
-    Returns:
-        List of Github issues.
-    """
-
-    if issue_type == "issue":
-        url = f"https://api.github.com/repos/{owner}/{repo}/issues"
-    else:
-        url = f"https://api.github.com/repos/{owner}/{repo}/pulls"
-
-    
-    headers = {
-        "Authorization": f"token {token}",
-        "Accept": "application/vnd.github.v3+json",
-    }
-    params: dict[str, int | str] = {"state": "open", "per_page": 100, "page": 1}
-    all_issues = []
-
-    while True:
-        response = requests.get(url, headers=headers, params=params)
-        response.raise_for_status()
-        issues = response.json()
-
-        if not issues:
-            break
-
-        if not isinstance(issues, list) or any(
-            [not isinstance(issue, dict) for issue in issues]
-        ):
-            raise ValueError("Expected list of dictionaries from Github API.")
-
-        all_issues.extend(issues)
-        assert isinstance(params["page"], int)
-        params["page"] += 1
-    converted_issues = []
-    for issue in all_issues:
-        if any([issue.get(key) is None for key in ["number", "title", "body"]]):
-            logger.warning(
-                f"Skipping issue {issue} as it is missing number, title, or body."
-            )
-            continue
-
-        # Skip pull requests only for regular issues
-        if issue_type == "issue" and "pull_request" in issue:
-            continue
-        
-        
-        
-        if issue_type == "pr":
-            closing_issues, unresolved_comments = download_pr_metadata(owner, repo, token, issue["number"])
-            head_branch = issue["head"]["ref"]
-            issue_details = GithubIssue(
-                                owner=owner,
-                                repo=repo,
-                                number=issue["number"],
-                                title=issue["title"],
-                                body=issue["body"],
-                                closing_issues=closing_issues,
-                                review_comments=unresolved_comments,
-                                head_branch=head_branch
-                            )
-            
-            print(closing_issues, unresolved_comments, issue["number"])
-        else:
-            issue_details = GithubIssue(
-                                owner=owner,
-                                repo=repo,
-                                number=issue["number"],
-                                title=issue["title"],
-                                body=issue["body"],
-                            )
-            
-        converted_issues.append(issue_details)
-    return converted_issues
-
 
 # This function tracks the progress AND write the output to a JSONL file
 async def update_progress(output: Awaitable[ResolverOutput], output_fp: TextIO, pbar: tqdm) -> None:
@@ -604,6 +310,14 @@ async def update_progress(output: Awaitable[ResolverOutput], output_fp: TextIO, 
     )
     output_fp.write(resolved_output.model_dump_json() + "\n")
     output_fp.flush()
+
+def issue_handler_factory(issue_type: str, owner: str, repo: str, token: str) -> IssueHandlerInterface:
+    if issue_type == "issue":
+        return IssueHandler(owner, repo, token)
+    elif issue_type == "pr":
+        return PRHandler(owner, repo, token)
+    else:
+        raise ValueError(f"Invalid issue type: {issue_type}")
 
 
 async def resolve_issues(
@@ -638,10 +352,10 @@ async def resolve_issues(
         issue_numbers: List of issue numbers to resolve.
     """
 
+    issue_handler = issue_handler_factory(issue_type, owner, repo, token)
+
     # Load dataset
-    issues: list[GithubIssue] = download_issues_from_github(
-        owner, repo, token, issue_type
-    )
+    issues: list[GithubIssue] = issue_handler.get_converted_issues()
     
     if issue_numbers is not None:
         issues = [issue for issue in issues if issue.number in issue_numbers]
@@ -750,7 +464,7 @@ async def resolve_issues(
                     output_dir,
                     runtime_container_image,
                     prompt_template,
-                    issue_type,
+                    issue_handler,
                     repo_instruction,
                     bool(num_workers > 1),
                 ),


### PR DESCRIPTION
This PR addresses the last comment in #174 

> There are lots of "if" statements switching between issue and PR that we might want to refactor a little later to simplify the logic, but overall this is a good change and we should get it in.

Opened this PR as it was a quick refactor

# Summary
1. Created abstract class in `openhands_resolver/issue_definitions.py`; `IssueHandlerInterface` defines an issue handler that must contain the methods `get_converted_issues`, `get_instruction`, `get_success` (functions that previously contained statement switching)
2. Created `IssueHandler` which inherits `IssueHandlerInterface`; this resolves `issue-type=issue`
3. Create `PRHandler` which inherits `IssueHandler`; this resolves `issue-type=pr` (inheritance help with modularity)
4. Refactored test cases in `tests/test_resolve_issues.py` to work on newly defined classes