### PR TITLE
Sending PR Updates

### DIFF
--- a/openhands_resolver/github_issue.py
+++ b/openhands_resolver/github_issue.py
@@ -9,5 +9,5 @@ class GithubIssue(BaseModel):
     body: str
     closing_issues: list[str] | None = None
     review_comments: list[str] | None = None
-    last_comment_ids: list[str] | None = None
+    thread_ids: list[str] | None = None
     head_branch: str | None = None

--- a/openhands_resolver/github_issue.py
+++ b/openhands_resolver/github_issue.py
@@ -9,5 +9,4 @@ class GithubIssue(BaseModel):
     body: str
     closing_issues: list[str] | None = None
     review_comments: list[str] | None = None
-    last_comment_ids: list[int] | None = None
     head_branch: str | None = None

--- a/openhands_resolver/github_issue.py
+++ b/openhands_resolver/github_issue.py
@@ -9,4 +9,5 @@ class GithubIssue(BaseModel):
     body: str
     closing_issues: list[str] | None = None
     review_comments: list[str] | None = None
+    last_comment_ids: list[str] | None = None
     head_branch: str | None = None

--- a/openhands_resolver/github_issue.py
+++ b/openhands_resolver/github_issue.py
@@ -9,4 +9,5 @@ class GithubIssue(BaseModel):
     body: str
     closing_issues: list[str] | None = None
     review_comments: list[str] | None = None
+    last_comment_ids: list[int] | None = None
     head_branch: str | None = None

--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -189,12 +189,12 @@ class PRHandler(IssueHandler):
                             reviewThreads(first: 100) {
                                 edges{
                                     node{
+                                        id
                                         isResolved
                                         comments(first: 100) {
                                             totalCount
                                             nodes {
                                                 body
-                                                id
                                             }
                                         }
                                     }
@@ -232,16 +232,17 @@ class PRHandler(IssueHandler):
 
         # Get unresolved review comments
         unresolved_comments = []
-        last_comment_ids = []  # To store the last comment ID of each thread; agent replies to this comment
+        thread_ids = []  # Store comment thread IDs; agent replies to the thread
         review_threads = pr_data.get("reviewThreads", {}).get("edges", [])
         for thread in review_threads:
             node = thread.get("node", {})
             if not node.get("isResolved", True):  # Check if the review thread is unresolved
+                id = node.get("id")
+                thread_ids.append(id)
                 comments = node.get("comments", {}).get("nodes", [])
                 message = ""
                 for i, comment in enumerate(comments):
                     if i == len(comments) - 1:  # Check if it's the last comment in the thread
-                        last_comment_ids.append(comment["id"]) # Store the last comment's ID
                         if len(comments) > 1:
                             message += "---\n"  # Add "---" before the last message if there's more than one comment
                         message += "latest feedback:\n" + comment["body"] + "\n"
@@ -249,7 +250,7 @@ class PRHandler(IssueHandler):
                         message += comment["body"] + "\n"  # Add each comment in a new line
                 unresolved_comments.append(message)
 
-        return closing_issues_bodies, unresolved_comments, last_comment_ids
+        return closing_issues_bodies, unresolved_comments, thread_ids
 
 
     # Override processing of downloaded issues
@@ -263,7 +264,7 @@ class PRHandler(IssueHandler):
                 )
                 continue            
 
-            closing_issues, unresolved_comments, last_comment_ids = self.__download_pr_metadata(issue["number"])
+            closing_issues, unresolved_comments, thread_ids = self.__download_pr_metadata(issue["number"])
             head_branch = issue["head"]["ref"]
             issue_details = GithubIssue(
                                 owner=self.owner,
@@ -273,7 +274,7 @@ class PRHandler(IssueHandler):
                                 body=issue["body"],
                                 closing_issues=closing_issues,
                                 review_comments=unresolved_comments,
-                                last_comment_ids=last_comment_ids,
+                                thread_ids=thread_ids,
                                 head_branch=head_branch
                             )
             

--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -31,8 +31,6 @@ class IssueHandlerInterface(ABC):
         """Guess if the issue has been resolved based on the agent's output."""
         pass
 
-
-
     
 class IssueHandler(IssueHandlerInterface):
     issue_type: ClassVar[str] = "issue"
@@ -194,6 +192,7 @@ class PRHandler(IssueHandler):
                                             totalCount
                                             nodes {
                                                 body
+                                                id
                                             }
                                         }
                                     }
@@ -231,6 +230,8 @@ class PRHandler(IssueHandler):
 
         # Get unresolved review comments
         unresolved_comments = []
+        last_comment_ids = []  # To store the last comment ID of each thread; agent replies to this comment
+
         review_threads = pr_data.get("reviewThreads", {}).get("edges", [])
         for thread in review_threads:
             node = thread.get("node", {})
@@ -239,6 +240,7 @@ class PRHandler(IssueHandler):
                 message = ""
                 for i, comment in enumerate(comments):
                     if i == len(comments) - 1:  # Check if it's the last comment in the thread
+                        last_comment_ids.append(comment["id"]) # Store the last comment's ID
                         if len(comments) > 1:
                             message += "---\n"  # Add "---" before the last message if there's more than one comment
                         message += "latest feedback:\n" + comment["body"] + "\n"
@@ -246,7 +248,7 @@ class PRHandler(IssueHandler):
                         message += comment["body"] + "\n"  # Add each comment in a new line
                 unresolved_comments.append(message)
 
-        return closing_issues_bodies, unresolved_comments
+        return closing_issues_bodies, unresolved_comments, last_comment_ids
 
 
     # Override processing of downloaded issues
@@ -260,7 +262,7 @@ class PRHandler(IssueHandler):
                 )
                 continue            
 
-            closing_issues, unresolved_comments = self.__download_pr_metadata(issue["number"])
+            closing_issues, unresolved_comments, last_comment_ids = self.__download_pr_metadata(issue["number"])
             head_branch = issue["head"]["ref"]
             issue_details = GithubIssue(
                                 owner=self.owner,
@@ -270,6 +272,7 @@ class PRHandler(IssueHandler):
                                 body=issue["body"],
                                 closing_issues=closing_issues,
                                 review_comments=unresolved_comments,
+                                last_comment_ids=last_comment_ids,
                                 head_branch=head_branch
                             )
             
@@ -345,3 +348,26 @@ class PRHandler(IssueHandler):
         
         success = all(success_list)
         return success, success_list, json.dumps(explanation_list)
+    
+
+    def __reply_to_comment(self, pr_number: int, comment_id: int, reply: str):
+        url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/comments"
+
+        headers = {
+            'Authorization': 'Bearer YOUR_GITHUB_TOKEN',
+            'Content-Type': 'application/json'
+        }
+
+        data = {
+            "body": reply,
+            "in_reply_to_id": comment_id  # This is the comment ID you extracted from the GraphQL query
+        }
+
+        response = requests.post(url, json=data, headers=headers)
+        if response.status_code == 201:
+            print(f"Successfully replied to comment ID {comment_id}")
+        else:
+            print(f"Failed to reply: {response.status_code}, {response.text}")
+
+    def send_pull_request(self):
+        pass

--- a/openhands_resolver/resolve_issues.py
+++ b/openhands_resolver/resolve_issues.py
@@ -448,12 +448,19 @@ async def resolve_issues(
             # checkout to pr branch
             if issue_type == "pr":
                 logger.info(f"Checking out to PR branch {issue.head_branch} for issue {issue.number}")
-                subprocess.check_call(
-                    ["git", "fetch", "origin", f"pull/{issue.number}/head"],
+                
+                subprocess.check_output(
+                    ["git", "checkout", f"{issue.head_branch}"],
                     cwd=repo_dir,
                 )
 
-
+                base_commit = (
+                    subprocess.check_output(
+                        ["git", "rev-parse", "HEAD"], cwd=repo_dir
+                    )
+                    .decode("utf-8")
+                    .strip()
+                )
 
             task = update_progress(
                 process_issue(

--- a/openhands_resolver/send_pull_request.py
+++ b/openhands_resolver/send_pull_request.py
@@ -10,24 +10,24 @@ from openhands_resolver.patching import parse_patch, apply_diff
 import requests
 import subprocess
 import shlex
+import json
 
 from openhands_resolver.resolver_output import ResolverOutput
 
 
 def apply_patch(repo_dir: str, patch: str) -> None:
     diffs = parse_patch(patch)
-
     for diff in diffs:
         if not diff.header.new_path:
             print("Warning: Could not determine file to patch")
             continue
 
         old_path = (
-            os.path.join(repo_dir, diff.header.old_path.lstrip("b/"))
+            os.path.join(repo_dir, diff.header.old_path.removeprefix("b/"))
             if diff.header.old_path and diff.header.old_path != "/dev/null"
             else None
         )
-        new_path = os.path.join(repo_dir, diff.header.new_path.lstrip("b/"))
+        new_path = os.path.join(repo_dir, diff.header.new_path.removeprefix("b/"))
 
         # Check if the file is being deleted
         if diff.header.new_path == "/dev/null":
@@ -74,10 +74,10 @@ def apply_patch(repo_dir: str, patch: str) -> None:
 
 
 def initialize_repo(
-    output_dir: str, issue_number: int, base_commit: str | None = None
+    output_dir: str, issue_number: int, issue_type: str, base_commit: str | None = None
 ) -> str:
     src_dir = os.path.join(output_dir, "repo")
-    dest_dir = os.path.join(output_dir, "patches", f"issue_{issue_number}")
+    dest_dir = os.path.join(output_dir, "patches", f"{issue_type}_{issue_number}")
 
     if not os.path.exists(src_dir):
         raise ValueError(f"Source directory {src_dir} does not exist.")
@@ -102,8 +102,7 @@ def initialize_repo(
     return dest_dir
 
 
-def make_commit(repo_dir: str, issue: GithubIssue) -> None:
-
+def make_commit(repo_dir: str, issue: GithubIssue, issue_type: str) -> None:
     # Check if git username is set
     result = subprocess.run(
         f"git -C {repo_dir} config user.name",
@@ -111,6 +110,7 @@ def make_commit(repo_dir: str, issue: GithubIssue) -> None:
         capture_output=True,
         text=True,
     )
+
     if not result.stdout.strip():
         # If username is not set, configure git
         subprocess.run(
@@ -129,7 +129,7 @@ def make_commit(repo_dir: str, issue: GithubIssue) -> None:
         print(f"Error adding files: {result.stderr}")
         raise RuntimeError("Failed to add files to git")
 
-    commit_message = f"Fix issue #{issue.number}: {shlex.quote(issue.title)}"
+    commit_message = f"Fix {issue_type} #{issue.number}: {shlex.quote(issue.title)}"
     result = subprocess.run(
         f"git -C {repo_dir} commit -m {shlex.quote(commit_message)}",
         shell=True,
@@ -139,6 +139,7 @@ def make_commit(repo_dir: str, issue: GithubIssue) -> None:
     if result.returncode != 0:
         print(f"Error committing changes: {result.stderr}")
         raise RuntimeError("Failed to commit changes")
+
 
 
 
@@ -241,6 +242,88 @@ def send_pull_request(
 
     return url
 
+def reply_to_comment(github_token: str, comment_id: int, reply: str):
+    # Opting for graphql as REST API doesn't allow reply to replies in comment threads
+    query = """
+            mutation($body: String!, $pullRequestReviewThreadId: ID!) {
+                addPullRequestReviewThreadReply(input: { body: $body, pullRequestReviewThreadId: $pullRequestReviewThreadId }) {
+                    comment {
+                        id
+                        body
+                        createdAt
+                    }
+                }
+            }
+            """
+    
+    comment_reply = f"Openhands fix success summary\n\n\n{reply}"
+    variables = {
+        "body": comment_reply,
+        "pullRequestReviewThreadId": comment_id  
+    }
+    url = "https://api.github.com/graphql"
+    headers = {
+            "Authorization": f"Bearer {github_token}",
+            "Content-Type": "application/json"
+    }
+
+    response = requests.post(url, json={"query": query, "variables": variables}, headers=headers)
+    response.raise_for_status()
+
+
+def update_existing_pull_request(
+    github_issue: GithubIssue,
+    github_token: str,
+    github_username: str | None,
+    patch_dir: str,
+    comment_message: str = "New openhands update",
+    additional_message: str | None = None,
+) -> str:
+    # Set up headers and base URL for GitHub API
+    headers = {
+        "Authorization": f"token {github_token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    base_url = f"https://api.github.com/repos/{github_issue.owner}/{github_issue.repo}"   
+    branch_name = github_issue.head_branch
+
+    # Push the changes to the existing branch
+    push_command = (
+        f"git -C {patch_dir} push "
+        f"https://{github_username}:{github_token}@github.com/"
+        f"{github_issue.owner}/{github_issue.repo}.git {branch_name}"
+    )
+
+    result = subprocess.run(push_command, shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error pushing changes: {result.stderr}")
+        raise RuntimeError("Failed to push changes to the remote repository")
+
+    pr_url = f"https://github.com/{github_issue.owner}/{github_issue.repo}/pull/{github_issue.number}"
+    print(f"Updated pull request {pr_url} with new patches.")
+
+
+    # Send PR Comments
+    # TODO: run a summary of all comment success indicators for PR message
+    if comment_message:
+        comment_url = f"{base_url}/issues/{github_issue.number}/comments"
+        comment_data = {
+            "body": comment_message
+        }
+        comment_response = requests.post(comment_url, headers=headers, json=comment_data)
+        if comment_response.status_code != 201:
+            print(f"Failed to post comment: {comment_response.status_code} {comment_response.text}")
+        else:
+            print(f"Comment added to the PR: {comment_message}")
+
+    explanations = json.loads(additional_message)
+    for count in range(len(github_issue.thread_ids)):
+        reply_comment = explanations[count]
+        comment_id = github_issue.thread_ids[count]
+        reply_to_comment(github_token, comment_id, reply_comment)
+    
+    return pr_url
+
 
 def process_single_issue(
     output_dir: str,
@@ -257,23 +340,45 @@ def process_single_issue(
         )
         return
 
+    issue_type = resolver_output.issue_type
+
+    if issue_type == "issue":
+        base_commit = resolver_output.base_commit
+    elif issue_type == "pr":
+        base_commit = resolver_output.issue.head_branch
+    else:
+        raise ValueError(f"Invalid issue type: {issue_type}")
+
+
     patched_repo_dir = initialize_repo(
-        output_dir, resolver_output.issue.number, resolver_output.base_commit
+        output_dir, 
+        resolver_output.issue.number, 
+        issue_type, 
+        base_commit
     )
 
     apply_patch(patched_repo_dir, resolver_output.git_patch)
 
-    make_commit(patched_repo_dir, resolver_output.issue)
+    make_commit(patched_repo_dir, resolver_output.issue, issue_type)
 
-    send_pull_request(
-        github_issue=resolver_output.issue,
-        github_token=github_token,
-        github_username=github_username,
-        patch_dir=patched_repo_dir,
-        pr_type=pr_type,
-        fork_owner=fork_owner,
-        additional_message=resolver_output.success_explanation,
-    )
+    if issue_type == "pr":
+        update_existing_pull_request(
+            github_issue=resolver_output.issue,
+            github_token=github_token,
+            github_username=github_username,
+            patch_dir=patched_repo_dir,
+            additional_message=resolver_output.success_explanation
+        )
+    else:
+        send_pull_request(
+            github_issue=resolver_output.issue,
+            github_token=github_token,
+            github_username=github_username,
+            patch_dir=patched_repo_dir,
+            pr_type=pr_type,
+            fork_owner=fork_owner,
+            additional_message=resolver_output.success_explanation,
+        )
 
 
 def process_all_successful_issues(

--- a/tests/test_resolve_issues.py
+++ b/tests/test_resolve_issues.py
@@ -134,6 +134,7 @@ def test_download_issues_from_github():
     assert [issue.title for issue in issues] == ["Issue 1", "Issue 2"]
     assert [issue.review_comments for issue in issues] == [None, None]
     assert [issue.closing_issues for issue in issues] == [None, None]
+    assert [issue.thread_ids for issue in issues] == [None, None]
 
 
 def test_download_pr_from_github():
@@ -166,10 +167,11 @@ def test_download_pr_from_github():
                             {
                                 "node": {
                                     "isResolved": False,
+                                    "id": "1",
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Unresolved comment 1", "id": "1"},
-                                            {"body": "Follow up thread", "id": "2"}
+                                            {"body": "Unresolved comment 1"},
+                                            {"body": "Follow up thread"}
                                         ]
                                     }
                                 }
@@ -177,9 +179,10 @@ def test_download_pr_from_github():
                             {
                                 "node": {
                                     "isResolved": True,
+                                    "id": "2",
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Resolved comment 1", "id": "3"},
+                                            {"body": "Resolved comment 1"},
                                         ]
                                     }
                                 }
@@ -187,9 +190,10 @@ def test_download_pr_from_github():
                             {
                                 "node": {
                                     "isResolved": False,
+                                    "id": "3",
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Unresolved comment 3", "id": "4"},
+                                            {"body": "Unresolved comment 3"},
                                         ]
                                     }
                                 }
@@ -216,7 +220,7 @@ def test_download_pr_from_github():
     assert [issue.head_branch for issue in issues] == ["b1", "b2", "b3"]
     assert issues[0].review_comments == ["Unresolved comment 1\n---\nlatest feedback:\nFollow up thread\n", "latest feedback:\nUnresolved comment 3\n"]
     assert issues[0].closing_issues == ["Issue 1 body", "Issue 2 body"]
-    assert issues[0].last_comment_ids == ["2", "4"]
+    assert issues[0].thread_ids == ["1", "3"]
 
 @pytest.mark.asyncio
 async def test_complete_runtime():

--- a/tests/test_resolve_issues.py
+++ b/tests/test_resolve_issues.py
@@ -168,8 +168,8 @@ def test_download_pr_from_github():
                                     "isResolved": False,
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Unresolved comment 1", "id": 1},
-                                            {"body": "Follow up thread", "id": 2}
+                                            {"body": "Unresolved comment 1"},
+                                            {"body": "Follow up thread"}
                                         ]
                                     }
                                 }
@@ -179,7 +179,7 @@ def test_download_pr_from_github():
                                     "isResolved": True,
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Resolved comment 1", "id": 3},
+                                            {"body": "Resolved comment 1"},
                                         ]
                                     }
                                 }
@@ -189,7 +189,7 @@ def test_download_pr_from_github():
                                     "isResolved": False,
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Unresolved comment 3", "id": 4},
+                                            {"body": "Unresolved comment 3"},
                                         ]
                                     }
                                 }
@@ -216,7 +216,6 @@ def test_download_pr_from_github():
     assert [issue.head_branch for issue in issues] == ["b1", "b2", "b3"]
     assert issues[0].review_comments == ["Unresolved comment 1\n---\nlatest feedback:\nFollow up thread\n", "latest feedback:\nUnresolved comment 3\n"]
     assert issues[0].closing_issues == ["Issue 1 body", "Issue 2 body"]
-    assert issues[0].last_comment_ids == [2, 4]
 
 
 @pytest.mark.asyncio

--- a/tests/test_resolve_issues.py
+++ b/tests/test_resolve_issues.py
@@ -168,8 +168,8 @@ def test_download_pr_from_github():
                                     "isResolved": False,
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Unresolved comment 1"},
-                                            {"body": "Follow up thread"}
+                                            {"body": "Unresolved comment 1", "id": 1},
+                                            {"body": "Follow up thread", "id": 2}
                                         ]
                                     }
                                 }
@@ -179,7 +179,7 @@ def test_download_pr_from_github():
                                     "isResolved": True,
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Resolved comment 1"},
+                                            {"body": "Resolved comment 1", "id": 3},
                                         ]
                                     }
                                 }
@@ -189,7 +189,7 @@ def test_download_pr_from_github():
                                     "isResolved": False,
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Unresolved comment 3"},
+                                            {"body": "Unresolved comment 3", "id": 4},
                                         ]
                                     }
                                 }
@@ -216,6 +216,7 @@ def test_download_pr_from_github():
     assert [issue.head_branch for issue in issues] == ["b1", "b2", "b3"]
     assert issues[0].review_comments == ["Unresolved comment 1\n---\nlatest feedback:\nFollow up thread\n", "latest feedback:\nUnresolved comment 3\n"]
     assert issues[0].closing_issues == ["Issue 1 body", "Issue 2 body"]
+    assert issues[0].last_comment_ids == [2, 4]
 
 
 @pytest.mark.asyncio

--- a/tests/test_resolve_issues.py
+++ b/tests/test_resolve_issues.py
@@ -168,8 +168,8 @@ def test_download_pr_from_github():
                                     "isResolved": False,
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Unresolved comment 1"},
-                                            {"body": "Follow up thread"}
+                                            {"body": "Unresolved comment 1", "id": "1"},
+                                            {"body": "Follow up thread", "id": "2"}
                                         ]
                                     }
                                 }
@@ -179,7 +179,7 @@ def test_download_pr_from_github():
                                     "isResolved": True,
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Resolved comment 1"},
+                                            {"body": "Resolved comment 1", "id": "3"},
                                         ]
                                     }
                                 }
@@ -189,7 +189,7 @@ def test_download_pr_from_github():
                                     "isResolved": False,
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Unresolved comment 3"},
+                                            {"body": "Unresolved comment 3", "id": "4"},
                                         ]
                                     }
                                 }
@@ -216,7 +216,7 @@ def test_download_pr_from_github():
     assert [issue.head_branch for issue in issues] == ["b1", "b2", "b3"]
     assert issues[0].review_comments == ["Unresolved comment 1\n---\nlatest feedback:\nFollow up thread\n", "latest feedback:\nUnresolved comment 3\n"]
     assert issues[0].closing_issues == ["Issue 1 body", "Issue 2 body"]
-
+    assert issues[0].last_comment_ids == ["2", "4"]
 
 @pytest.mark.asyncio
 async def test_complete_runtime():

--- a/tests/test_send_pull_request.py
+++ b/tests/test_send_pull_request.py
@@ -192,9 +192,10 @@ index 9daeafb..0000000
 
 
 def test_initialize_repo(mock_output_dir):
+    issue_type = "issue"
     # Copy the repo to patches
     ISSUE_NUMBER = 3
-    initialize_repo(mock_output_dir, ISSUE_NUMBER)
+    initialize_repo(mock_output_dir, ISSUE_NUMBER, issue_type)
     patches_dir = os.path.join(mock_output_dir, "patches", f"issue_{ISSUE_NUMBER}")
 
     # Check if files were copied correctly
@@ -409,12 +410,12 @@ def test_process_single_issue(
     )
 
     # Assert that the mocked functions were called with correct arguments
-    mock_initialize_repo.assert_called_once_with(mock_output_dir, 1, "def456")
+    mock_initialize_repo.assert_called_once_with(mock_output_dir, 1, "issue", "def456")
     mock_apply_patch.assert_called_once_with(
         f"{mock_output_dir}/patches/issue_1", resolver_output.git_patch
     )
     mock_make_commit.assert_called_once_with(
-        f"{mock_output_dir}/patches/issue_1", resolver_output.issue
+        f"{mock_output_dir}/patches/issue_1", resolver_output.issue, "issue"
     )
     mock_send_pull_request.assert_called_once_with(
         github_issue=resolver_output.issue,
@@ -705,7 +706,8 @@ def test_make_commit_escapes_issue_title(mock_subprocess_run):
     mock_subprocess_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
 
     # Call the function
-    make_commit(repo_dir, issue)
+    issue_type = "issue"
+    make_commit(repo_dir, issue, issue_type)
 
     # Assert that subprocess.run was called with the correct arguments
     calls = mock_subprocess_run.call_args_list


### PR DESCRIPTION
# Summary

#174 executed openhands agents to address unresolved comments on user's PRs. We've made changes in `openhands_resolver/send_pull_request.py` to update  the user's PRs with the new generated code. Summary of changes made to the codebase are described below - 

1. Checkout to "PR" branch instead of base commit ID when initializing repo
2. Commit to the existing branch, instead of creating a new one (this updates the existing PR with new code)
3. Add a comment on the PR indicating new updates were made
4. Reply to every unresolved comment thread with a summary of changes made by openhands
5. Updated test cases to reflect new workflow

# Possible Future work
## PR Update Message
Currently the message is fixed ("New openhands update"); this can be changes to be an AI generated summary of all updates made to each unresolved comment

## Agentic Workflow 
Inline review comments inherently localize to a specific code file. Openhands' agents don't utilize this context and spend time localizing to which file the comments apply to. Perhaps the user can have an indicator that forces openhands to start making changes from a specific file?

Possible benefits - 
- reliability
- lowered cost
- faster resolution time (especially when comments have smaller scopes)