### PR TITLE
Fix issue #209: When a patch with a renamed file is generated, workflow fails with an error

### DIFF
--- a/openhands_resolver/send_pull_request.py
+++ b/openhands_resolver/send_pull_request.py
@@ -42,12 +42,11 @@ def apply_patch(repo_dir: str, patch: str) -> None:
             continue
 
         # Handle file rename
-        if diff.header.old_path and diff.header.new_path and "rename from" in patch and "rename to" in patch:
-            if os.path.exists(old_path):
-                os.makedirs(os.path.dirname(new_path), exist_ok=True)
-                shutil.copy2(old_path, new_path)
-                os.remove(old_path)
-                continue
+        if old_path and new_path and "rename from" in patch:
+            os.makedirs(os.path.dirname(new_path), exist_ok=True)
+            shutil.copy2(old_path, new_path)
+            os.remove(old_path)
+            continue
 
         if old_path:
             # Open the file in binary mode to detect line endings

--- a/openhands_resolver/send_pull_request.py
+++ b/openhands_resolver/send_pull_request.py
@@ -25,12 +25,13 @@ def apply_patch(repo_dir: str, patch: str) -> None:
             print("Warning: Could not determine file to patch")
             continue
 
+        # Remove both "a/" and "b/" prefixes from paths
         old_path = (
-            os.path.join(repo_dir, diff.header.old_path.removeprefix("b/"))
+            os.path.join(repo_dir, diff.header.old_path.removeprefix("a/").removeprefix("b/"))
             if diff.header.old_path and diff.header.old_path != "/dev/null"
             else None
         )
-        new_path = os.path.join(repo_dir, diff.header.new_path.removeprefix("b/"))
+        new_path = os.path.join(repo_dir, diff.header.new_path.removeprefix("a/").removeprefix("b/"))
 
         # Check if the file is being deleted
         if diff.header.new_path == "/dev/null":
@@ -39,6 +40,14 @@ def apply_patch(repo_dir: str, patch: str) -> None:
                 os.remove(old_path)
                 print(f"Deleted file: {old_path}")
             continue
+
+        # Handle file rename
+        if diff.header.old_path and diff.header.new_path and "rename from" in patch and "rename to" in patch:
+            if os.path.exists(old_path):
+                os.makedirs(os.path.dirname(new_path), exist_ok=True)
+                shutil.copy2(old_path, new_path)
+                os.remove(old_path)
+                continue
 
         if old_path:
             # Open the file in binary mode to detect line endings
@@ -565,6 +574,8 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+
 
 
 

--- a/tests/test_send_pull_request.py
+++ b/tests/test_send_pull_request.py
@@ -173,6 +173,32 @@ index 0000000..3b18e51
     assert content == "hello world", "File content is incorrect"
 
 
+def test_apply_patch_rename_file(mock_output_dir):
+    # Create a sample file in the mock repo
+    old_file = os.path.join(mock_output_dir, "old_name.txt")
+    with open(old_file, "w") as f:
+        f.write("This file will be renamed")
+
+    # Create a patch that renames the file
+    patch_content = """diff --git a/old_name.txt b/new_name.txt
+similarity index 100%
+rename from old_name.txt
+rename to new_name.txt"""
+
+    # Apply the patch
+    apply_patch(mock_output_dir, patch_content)
+
+    # Check if the file was renamed
+    new_file = os.path.join(mock_output_dir, "new_name.txt")
+    assert not os.path.exists(old_file), "Old file still exists"
+    assert os.path.exists(new_file), "New file was not created"
+
+    # Check if the content is preserved
+    with open(new_file, "r") as f:
+        content = f.read()
+    assert content == "This file will be renamed"
+
+
 def test_apply_patch_delete_file(mock_output_dir):
     # Create a sample file in the mock repo
     sample_file = os.path.join(mock_output_dir, "to_be_deleted.txt")
@@ -966,4 +992,6 @@ def test_make_commit_escapes_issue_title(mock_subprocess_run):
     expected_commit_message = "Fix issue #42: 'Issue with \"quotes\" and $pecial characters'"
     shlex_quote_message = shlex.quote(expected_commit_message)
     assert f"git -C {repo_dir} commit -m {shlex_quote_message}" in git_commit_call
+
+
 


### PR DESCRIPTION
This pull request fixes #209.

This PR addresses an issue where `send_pull_request.py` would fail when handling patches that rename files. The fix implements two key components:

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌