### PR TITLE
Fix import path

### DIFF
--- a/openhands_resolver/resolve_issues.py
+++ b/openhands_resolver/resolve_issues.py
@@ -243,6 +243,7 @@ async def process_issue(
     config.set_llm_config(llm_config)
 
     runtime = create_runtime(config, sid=f"{issue.number}")
+    await runtime.connect() 
     initialize_runtime(runtime)
 
     instruction = issue_handler.get_instruction(issue, prompt_template, repo_instruction)

--- a/openhands_resolver/resolve_issues.py
+++ b/openhands_resolver/resolve_issues.py
@@ -37,7 +37,7 @@ from openhands.core.config import (
     SandboxConfig,
 )
 from openhands.core.config import LLMConfig
-from openhands.runtime.runtime import Runtime
+from openhands.runtime.base import Runtime
 from openhands_resolver.utils import (
     codeact_user_response,
     reset_logger_for_multiprocessing,


### PR DESCRIPTION
The file which contained `Runtime` was renamed in `Openhands` (can be found in this [this commit](https://github.com/All-Hands-AI/OpenHands/commit/2d5b360505d82c810c020599310c6fbf1d5721c0#diff-f44be5165f0c0e0e81253e33b8e399aef13c0ce763f543c32c8b3db2b915a734R15))

Plans to upgrade `openhands-resolver` have been made; this PR fixes the import issue.