### PR TITLE
Localization enhancement

### DIFF
--- a/openhands_resolver/github_issue.py
+++ b/openhands_resolver/github_issue.py
@@ -1,4 +1,10 @@
 from pydantic import BaseModel
+from typing import TypedDict
+
+
+class ReviewComment(TypedDict):
+    comment: str
+    files: str
 
 
 class GithubIssue(BaseModel):
@@ -8,6 +14,6 @@ class GithubIssue(BaseModel):
     title: str
     body: str
     closing_issues: list[str] | None = None
-    review_comments: list[str] | None = None
+    review_comments: list[ReviewComment] | None = None
     thread_ids: list[str] | None = None
     head_branch: str | None = None

--- a/openhands_resolver/github_issue.py
+++ b/openhands_resolver/github_issue.py
@@ -4,7 +4,7 @@ from typing import TypedDict
 
 class ReviewComment(TypedDict):
     comment: str
-    files: str
+    files: list[str]
 
 
 class GithubIssue(BaseModel):

--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -195,6 +195,7 @@ class PRHandler(IssueHandler):
                                             totalCount
                                             nodes {
                                                 body
+                                                path
                                             }
                                         }
                                     }
@@ -241,6 +242,7 @@ class PRHandler(IssueHandler):
                 thread_ids.append(id)
                 comments = node.get("comments", {}).get("nodes", [])
                 message = ""
+                files = []
                 for i, comment in enumerate(comments):
                     if i == len(comments) - 1:  # Check if it's the last comment in the thread
                         if len(comments) > 1:
@@ -248,7 +250,16 @@ class PRHandler(IssueHandler):
                         message += "latest feedback:\n" + comment["body"] + "\n"
                     else:
                         message += comment["body"] + "\n"  # Add each comment in a new line
-                unresolved_comments.append(message)
+                    
+                    file = comment.get("path")
+                    if file:
+                        files.append(file)
+
+                unresolved_comment = {
+                    "comment": message,
+                    "files": files
+                }
+                unresolved_comments.append(unresolved_comment)
 
         return closing_issues_bodies, unresolved_comments, thread_ids
 

--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -301,8 +301,12 @@ class PRHandler(IssueHandler):
         if issue.closing_issues is None or issue.review_comments is None:
             raise ValueError("issue.closing_issues or issue.review_comments is None")
         issues_context = json.dumps(issue.closing_issues, indent=4)
-        comment_chain = json.dumps(issue.review_comments, indent=4)
-        instruction = template.render(issues=issues_context, body=comment_chain, repo_instruction=repo_instruction)
+        comments = [review_comment["commment"] for review_comment in issue.review_comments]
+        comment_files = [review_comment["files"] for review_comment in issue.review_comments]
+        comment_chain = json.dumps(comments, indent=4)
+        files = json.dumps(comment_files, indent=4)
+
+        instruction = template.render(issues=issues_context, files=files, body=comment_chain, repo_instruction=repo_instruction)
         return instruction
     
 
@@ -315,15 +319,20 @@ class PRHandler(IssueHandler):
         explanation_list = []
 
         if issue.review_comments:
-            for comment in issue.review_comments:
-                formatted_comment = json.dumps(comment, indent=4)
-                prompt = f"""You are given one or more issue descriptions, a piece of feedback to resolve the issues, and the last message from an AI agent attempting to incorporate the feedback. Determine if the feedback has been successfully resolved.
+            for review_comment in issue.review_comments:
+                formatted_comment = json.dumps(review_comment["comment"], indent=4)
+                files_context = json.dumps(review_comment["files"], indent=4)
+
+                prompt = f"""You are given one or more issue descriptions, a piece of feedback to resolve the issues, and the last message from an AI agent attempting to incorporate the feedback. If the feedback is addressed to a specific code file, then the file locations will be provided as well. Determine if the feedback has been successfully resolved.
                 
                 Issue descriptions:
                 {issues_context}
 
                 Feedback:
                 {formatted_comment}
+
+                Files locations:
+                {files_context}
 
                 Last message from AI agent:
                 {last_message}

--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -301,8 +301,10 @@ class PRHandler(IssueHandler):
         if issue.closing_issues is None or issue.review_comments is None:
             raise ValueError("issue.closing_issues or issue.review_comments is None")
         issues_context = json.dumps(issue.closing_issues, indent=4)
-        comments = [review_comment["commment"] for review_comment in issue.review_comments]
-        comment_files = [review_comment["files"] for review_comment in issue.review_comments]
+        comments = [review_comment["comment"] for review_comment in issue.review_comments]
+        comment_files = []
+        for review_comment in issue.review_comments:
+            comment_files.extend(review_comment["files"])
         comment_chain = json.dumps(comments, indent=4)
         files = json.dumps(comment_files, indent=4)
 

--- a/openhands_resolver/prompts/resolve/basic-followup.jinja
+++ b/openhands_resolver/prompts/resolve/basic-followup.jinja
@@ -1,9 +1,13 @@
 The current code is an attempt at fixing one or more issues. The code is not satisfactory and follow up feedback have been provided to address this.
+The feedback may be addressed to specific code files. In this case the file locations will be provided.
 Please update the code based on the feedback for the repository in /workspace.
 An environment has been set up for you to start working. You may assume all necessary tools are installed.
 
 # Issues addressed 
 {{ issues }}
+
+# File locations
+{{ files }}
 
 # Feedback chain
 {{ body }}

--- a/tests/test_resolve_issues.py
+++ b/tests/test_resolve_issues.py
@@ -170,7 +170,7 @@ def test_download_pr_from_github():
                                     "id": "1",
                                     "comments": {
                                         "nodes": [
-                                            {"body": "Unresolved comment 1"},
+                                            {"body": "Unresolved comment 1", "path": "/frontend/header.tsx"},
                                             {"body": "Follow up thread"}
                                         ]
                                     }
@@ -220,6 +220,8 @@ def test_download_pr_from_github():
     assert [issue.head_branch for issue in issues] == ["b1", "b2", "b3"]
     
     assert [review_comment["comment"] for review_comment in issues[0].review_comments] == ["Unresolved comment 1\n---\nlatest feedback:\nFollow up thread\n", "latest feedback:\nUnresolved comment 3\n"]
+    assert [len(review_comment["files"]) for review_comment in issues[0].review_comments] == [1, 0]
+    assert issues[0].review_comments[0]["files"] == ["/frontend/header.tsx"]
     assert issues[0].closing_issues == ["Issue 1 body", "Issue 2 body"]
     assert issues[0].thread_ids == ["1", "3"]
 

--- a/tests/test_send_pull_request.py
+++ b/tests/test_send_pull_request.py
@@ -553,7 +553,7 @@ def test_process_single_pr_update(
             title="Issue 1",
             body="Body 1",
             closing_issues=[],
-            review_comments=["review comment for feedback"],
+            review_comments=[{"comment": "review comment for feedback", "files":[]}],
             thread_ids= ["1"],
             head_branch="branch 1"
 


### PR DESCRIPTION
This PR addresses #189

# Current
Code agents don't consider file path locations for inline comments when performing localization during resolution phase. 

# Changes
1. Get file paths for inline comments
2. Prompt agent with file locations
3. Updated `GithubIssue` typings and test cases