### PR TITLE
Passing screenshot context from original issues to Agents

### DIFF
--- a/openhands_resolver/resolve_issues.py
+++ b/openhands_resolver/resolve_issues.py
@@ -245,10 +245,12 @@ async def process_issue(
     runtime = create_runtime(config, sid=f"{issue.number}")
     initialize_runtime(runtime)
 
-    instruction = issue_handler.get_instruction(issue, prompt_template, repo_instruction)
+
+    instruction, images_urls = issue_handler.get_instruction(issue, prompt_template, repo_instruction)
     # Here's how you can run the agent (similar to the `main` function) and get the final task state
     action = MessageAction(
         content=instruction,
+        images_urls=images_urls
     )
     state: State | None = await run_controller(
         config=config,


### PR DESCRIPTION
This PR addresses #213 

Changes
1. Extract all image links from body or review threads with format `![alt text](url.com)`
2. Pass them to the `MessageAction`
3. Updated test cases according to new functionality