### PR TITLE
Fixing prompt bug

### DIFF
--- a/openhands_resolver/prompts/resolve/basic-with-tests.jinja
+++ b/openhands_resolver/prompts/resolve/basic-with-tests.jinja
@@ -14,4 +14,4 @@ For all changes to actual application code (e.g. in Python or Javascript), add a
 Run the tests, and if they pass you are done!
 You do NOT need to write new tests if there are only changes to documentation or configuration files.
 
-When finished, run the following command: <execute_bash> exit </execute_bash>.
+When you think you have fixed the issue through code changes, please call the finish action to end the interaction.


### PR DESCRIPTION
This address issue #229 

After `Openhands` function calling was updated, `openhands_resolver/prompts/resolve/basic-with-tests.jinja` wasn't updated to use `finish action` instead of `<execute_bash>exit</execute_bash>`

# Changes
Replaced original line with 

`When you think you have fixed the issue through code changes, please call the finish action to end the interaction.`

Note that using 

`When you think you have fixed the issue through code changes, please finish the interaction.` still caused agent to call `exit`, and had to explicitly request that `finish action` be used.  