### PR TITLE
Fix issue #235: 'Logs are not printed unless `DEBUG=True` is set'

### DIFF
--- a/openhands_resolver/resolve_issue.py
+++ b/openhands_resolver/resolve_issue.py
@@ -199,6 +199,12 @@ async def process_issue(
 
     runtime = create_runtime(config, sid=f"{issue.number}")
     await runtime.connect()
+    
+    # Subscribe to event stream to ensure logs are printed
+    def on_event(evt):
+        print(evt)
+    runtime.event_stream.subscribe(on_event)
+    
     initialize_runtime(runtime)
 
     instruction, images_urls = issue_handler.get_instruction(issue, prompt_template, repo_instruction)


### PR DESCRIPTION
This attempts to subscribe to the event stream and print out logs.

Fixes #235 