### PR TITLE
fix: Update ShortTermHistory to EventStream

### DIFF
--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -6,7 +6,7 @@ import litellm
 import jinja2
 import json
 
-from openhands.memory.history import ShortTermHistory
+from openhands.events.stream import EventStream
 from openhands_resolver.github_issue import GithubIssue
 from openhands.core.config import LLMConfig
 from openhands.core.logger import openhands_logger as logger
@@ -27,7 +27,7 @@ class IssueHandlerInterface(ABC):
         pass
     
     @abstractmethod
-    def guess_success(self, issue: GithubIssue, history: ShortTermHistory, llm_config: LLMConfig) -> tuple[bool, list[bool] | None, str]:
+    def guess_success(self, issue: GithubIssue, history: EventStream, llm_config: LLMConfig) -> tuple[bool, list[bool] | None, str]:
         """Guess if the issue has been resolved based on the agent's output."""
         pass
 
@@ -148,10 +148,10 @@ class IssueHandler(IssueHandlerInterface):
 
 
 
-    def guess_success(self, issue: GithubIssue, history: ShortTermHistory, llm_config: LLMConfig) -> tuple[bool, None | list[bool], str]:
+    def guess_success(self, issue: GithubIssue, history: EventStream, llm_config: LLMConfig) -> tuple[bool, None | list[bool], str]:
         """Guess if the issue is fixed based on the history and the issue description."""
        
-        last_message = history.get_events_as_list()[-1].message    
+        last_message = list(history.get_events())[-1].message
         # Include thread comments in the prompt if they exist
         issue_context = issue.body
         if issue.thread_comments:
@@ -363,10 +363,10 @@ class PRHandler(IssueHandler):
         return instruction, images
     
 
-    def guess_success(self, issue: GithubIssue, history: ShortTermHistory, llm_config: LLMConfig) -> tuple[bool, None | list[bool], str]:
+    def guess_success(self, issue: GithubIssue, history: EventStream, llm_config: LLMConfig) -> tuple[bool, None | list[bool], str]:
         """Guess if the issue is fixed based on the history and the issue description."""
         
-        last_message = history.get_events_as_list()[-1].message
+        last_message = list(history.get_events())[-1].message
         issues_context = json.dumps(issue.closing_issues, indent=4)
         success_list = []
         explanation_list = []

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,9 +1,11 @@
 import pytest
 
 def test_required_imports():
-    """Test that all required imports are available."""
+    """Test that all required imports are available and classes are properly defined."""
     try:
         from openhands.events.stream import EventStream
+        # Verify EventStream is a class
+        assert isinstance(EventStream, type), "EventStream should be a class"
     except ImportError as e:
         pytest.fail(f"Failed to import EventStream: {str(e)}")
 
@@ -13,5 +15,8 @@ def test_required_imports():
             PRHandler,
             IssueHandlerInterface
         )
+        # Verify inheritance relationships
+        assert issubclass(IssueHandler, IssueHandlerInterface), "IssueHandler should inherit from IssueHandlerInterface"
+        assert issubclass(PRHandler, IssueHandler), "PRHandler should inherit from IssueHandler"
     except ImportError as e:
         pytest.fail(f"Failed to import from issue_definitions: {str(e)}")

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,17 @@
+import pytest
+
+def test_required_imports():
+    """Test that all required imports are available."""
+    try:
+        from openhands.events.stream import EventStream
+    except ImportError as e:
+        pytest.fail(f"Failed to import EventStream: {str(e)}")
+
+    try:
+        from openhands_resolver.issue_definitions import (
+            IssueHandler,
+            PRHandler,
+            IssueHandlerInterface
+        )
+    except ImportError as e:
+        pytest.fail(f"Failed to import from issue_definitions: {str(e)}")

--- a/tests/test_resolve_issues.py
+++ b/tests/test_resolve_issues.py
@@ -15,7 +15,7 @@ from openhands.events.action import CmdRunAction
 from openhands.events.observation import CmdOutputObservation, NullObservation
 from openhands_resolver.resolver_output import ResolverOutput
 from openhands.core.config import LLMConfig
-from openhands.memory.history import ShortTermHistory
+from openhands.events.stream import EventStream
 
 
 @pytest.fixture
@@ -484,8 +484,8 @@ def test_guess_success():
         title="Test Issue",
         body="This is a test issue",
     )
-    mock_history = MagicMock(spec=ShortTermHistory)
-    mock_history.get_events_as_list.return_value = [
+    mock_history = MagicMock(spec=EventStream)
+    mock_history.get_events.return_value = [
         create_cmd_output(
             exit_code=0,
             content="",
@@ -515,8 +515,8 @@ def test_guess_success_with_thread_comments():
         body="This is a test issue",
         thread_comments=["First comment", "Second comment", "latest feedback:\nPlease add tests"]
     )
-    mock_history = MagicMock(spec=ShortTermHistory)
-    mock_history.get_events_as_list.return_value = [
+    mock_history = MagicMock(spec=EventStream)
+    mock_history.get_events.return_value = [
         MagicMock(message="I have added tests for this case")
     ]
     mock_llm_config = LLMConfig(model="test_model", api_key="test_api_key")
@@ -568,8 +568,8 @@ def test_guess_success_failure():
         body="This is a test issue",
         thread_comments=["First comment", "Second comment", "latest feedback:\nPlease add tests"]
     )
-    mock_history = MagicMock(spec=ShortTermHistory)
-    mock_history.get_events_as_list.return_value = [
+    mock_history = MagicMock(spec=EventStream)
+    mock_history.get_events.return_value = [
         MagicMock(message="I have added tests for this case")
     ]
     mock_llm_config = LLMConfig(model="test_model", api_key="test_api_key")
@@ -594,8 +594,8 @@ def test_guess_success_negative_case():
         title="Test Issue",
         body="This is a test issue",
     )
-    mock_history = MagicMock(spec=ShortTermHistory)
-    mock_history.get_events_as_list.return_value = [
+    mock_history = MagicMock(spec=EventStream)
+    mock_history.get_events.return_value = [
         create_cmd_output(
             exit_code=0,
             content="",
@@ -626,8 +626,8 @@ def test_guess_success_invalid_output():
         title="Test Issue",
         body="This is a test issue",
     )
-    mock_history = MagicMock(spec=ShortTermHistory)
-    mock_history.get_events_as_list.return_value = [
+    mock_history = MagicMock(spec=EventStream)
+    mock_history.get_events.return_value = [
         create_cmd_output(
             exit_code=0,
             content="",


### PR DESCRIPTION
This PR fixes the import error by updating the code to use `EventStream` instead of the deprecated `ShortTermHistory` class.

Changes made:
- Replace deprecated `ShortTermHistory` with `EventStream` from `openhands.events.stream`
- Update method signatures in `IssueHandlerInterface` and implementations
- Add test to verify imports and dependencies
- Fix event list access using `list(history.get_events())`

This change is required because the `ShortTermHistory` class has been removed from the openhands-ai package and replaced with `EventStream`.