### PR TITLE
Fix issue #251: `openhands-resolver.yml` workflow is not triggered on pull requests

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -25,7 +25,7 @@ on:
   issues:
     types: [labeled]
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request fixes #251.

The issue has been successfully resolved. The AI agent updated the workflow file to trigger on multiple pull request events by adding the following triggers:

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌