### PR TITLE
[Enhancement]: Caching resolver dependency

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -45,6 +45,22 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Get latest versions and create requirements.txt
+        run: |
+          python -m pip index versions openhands-resolver > resolver_versions.txt
+          RESOLVER_VERSION=$(head -n 1 resolver_versions.txt | awk '{print $2}' | tr -d '()')
+          echo "openhands-resolver==${RESOLVER_VERSION}" >> requirements.txt
+          cat requirements.txt
+
+      - name: Cache pip dependencies
+        if: github.event.label.name == 'fix-me'
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}/lib/python3.12/site-packages/*
+          key: ${{ runner.os }}-pip-openhands-resolver-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-openhands-resolver-${{ hashFiles('requirements.txt') }}
+
       - name: Check required environment variables
         env:
           LLM_MODEL: ${{ secrets.LLM_MODEL }}
@@ -87,11 +103,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           if [ "${{ github.event.label.name }}" == "fix-me-experimental" ]; then
+            python -m pip install --upgrade pip
             pip install git+https://github.com/all-hands-ai/openhands-resolver.git
           else
-            pip install openhands-resolver
+            python -m pip install --upgrade -r requirements.txt
           fi
 
       - name: Attempt to resolve issue


### PR DESCRIPTION
This PR partially addresses issue #143 by caching the pip installation of `openhands-resolver`

# Changes
We invoke the caching workflow only when the label `fix-me` is used; we do the following
1. Check for the latest `openhands-resolver` version available
3. Create a new cache if is doesn't exist with `openhands-resolver` version used as the key, otherwise restore packages from the existing cache

This means 
1. If `fix-me-experimental` is used all caching workflows are skipped; this ensures the unreleased version is installed
2. If new version of `openhands-resolver` is released, a new cache will be created since the cache key won't exist. The older cache will [automatically be discarded by Github in 7 days if its not used.
](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy)

# Test logs
1. [Workflow log](https://github.com/malhotra5/test-repo/actions/runs/11734548480) where cache is created for the first time. 
2. [Workflow log](https://github.com/malhotra5/test-repo/actions/runs/11734618498) where cache hit occurs and packages are restored successfully from the cache. **Saves around 100 seconds of installation time**.
3. [Workflow log](https://github.com/malhotra5/test-repo/actions/runs/11734637138) where caching is ignored when `fix-me-experimental` label is used