### PR TITLE
Fix issue #287: PR updates with no file-level review comments result in error message

### DIFF
--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -524,9 +524,51 @@ class PRHandler(IssueHandler):
             else:
                 success_list.append(False)
                 explanation_list.append(f"Failed to decode answer from LLM response: {answer}")
+        elif issue.review_comments:
+            # Handle PRs with only review comments (no file-specific review comments or thread comments)
+            review_context = "\n---\n".join(issue.review_comments)
+            prompt = f"""You are given one or more issue descriptions, the PR review comments, and the last message from an AI agent attempting to address the feedback. Determine if the feedback has been successfully resolved.
+            
+            Issue descriptions:
+            {issues_context}
+
+            PR Review Comments:
+            {review_context}
+
+            Last message from AI agent:
+            {last_message}
+
+            (1) has the feedback been successfully incorporated?
+            (2) If the feedback has been incorporated, please provide an explanation of what was done that can be sent to a human reviewer on github. If the feedback has not been resolved, please provide an explanation of why.
+
+            Answer in exactly the format below, with only true or false for success, and an explanation of the result.
+
+            --- success
+            true/false
+
+            --- explanation
+            ...
+            """
+
+            response = litellm.completion(
+                model=llm_config.model,
+                messages=[{"role": "user", "content": prompt}],
+                api_key=llm_config.api_key,
+                base_url=llm_config.base_url,
+            )
+        
+            answer = response.choices[0].message.content.strip()
+            pattern = r'--- success\n*(true|false)\n*--- explanation*\n(.*)'
+            match = re.search(pattern, answer)
+            if match:
+                success_list.append(match.group(1).lower() == 'true')
+                explanation_list.append(match.group(2))
+            else:
+                success_list.append(False)
+                explanation_list.append(f"Failed to decode answer from LLM response: {answer}")
         else:
-            # No review comments or thread comments found
-            raise ValueError("Expected review comments or thread comments to be initialized.")
+            # No review comments, thread comments, or file-level review comments found
+            return False, None, "No feedback was found to process"
             
         # Return overall success (all must be true) and explanations
         if not success_list:


### PR DESCRIPTION
This pull request fixes #287.

The issue has been successfully resolved through changes to the `guess_success` method in the `PRHandler` class. The original problem occurred when PRs had no file-level review comments, causing the workflow to fail with an error message. The solution expanded the method to properly handle all comment scenarios:

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌