### PR TITLE
Fix issue #299: [Feat]: Save the output.jsonl file as an artifact for github workflows

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -130,6 +130,14 @@ jobs:
             echo "RESOLUTION_SUCCESS=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Upload output.jsonl as artifact
+        uses: actions/upload-artifact@v4
+        if: always()  # Upload even if the previous steps fail
+        with:
+          name: resolver-output
+          path: /tmp/output/output.jsonl
+          retention-days: 30  # Keep the artifact for 30 days
+
       - name: Create draft PR or push branch
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
This pull request fixes #299.

The issue has been successfully resolved. The AI agent implemented a solution that directly addresses the requirement to store output.jsonl files for debugging purposes after GitHub workflow execution.

The implementation is complete and appropriate because:
1. It uses the standard GitHub Actions artifact upload functionality (actions/upload-artifact@v4)
2. It ensures the file is captured even if the workflow fails (if: always())
3. It specifies a reasonable retention period (30 days)
4. It targets the correct file path (/tmp/output/output.jsonl)
5. It provides an easy way to access the debug information through GitHub's interface

For a human reviewer, I would summarize this PR as:
"This PR adds artifact storage functionality to the GitHub workflow to preserve output.jsonl files for debugging purposes. The files will be automatically uploaded after each workflow run and stored for 30 days, accessible through the GitHub Actions interface. The upload will occur even if the workflow fails, ensuring debug information is always available. No code changes were required, only workflow configuration updates."

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌