### PR TITLE
Fixing success message bug

### DIFF
--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -486,7 +486,7 @@ class PRHandler(IssueHandler):
         explanation_list = []
 
         # Handle PRs with file-specific review comments
-        if issue.review_threads is not None:
+        if issue.review_threads:
             for review_thread in issue.review_threads:
                 success, explanation = self._check_review_thread(review_thread, issues_context, last_message, llm_config)
                 success_list.append(success)


### PR DESCRIPTION
# Fix
This issue address #297 

When the issue is a PR, `openhands-resolver` checks for `review_threads`. If there are no review threads, `review_threads` is initialized as an empty list.

```python
if issue.review_threads is not None
```
Thus, this conditional is always true. Other conditions underneath that guess success for `thread_comments` or `review_comments` are never reached, which resulted in `openhands-resolver` always returning "No feedback was processed" and causing the update comment to be a generic response "New OpenHands update". 