### PR TITLE
[Feat]: Adding macro invocation for Github issues

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -23,6 +23,8 @@ on:
     types: [labeled]
   pull_request:
     types: [labeled]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: write
@@ -31,7 +33,11 @@ permissions:
 
 jobs:
   auto-fix:
-    if: github.event_name == 'workflow_call' || github.event.label.name == 'fix-me' || github.event.label.name == 'fix-me-experimental'
+    if: |
+      github.event_name == 'workflow_call' ||
+      github.event.label.name == 'fix-me' ||
+      github.event.label.name == 'fix-me-experimental' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@openhands-agent'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -83,6 +89,8 @@ jobs:
             echo "ISSUE_NUMBER=${{ github.event.issue.number }}" >> $GITHUB_ENV
             echo "ISSUE_TYPE=issue" >> $GITHUB_ENV
           fi
+
+          echo "COMMENT_ID=${{ github.event.comment.id || 'None' }}" >> $GITHUB_ENV
           echo "MAX_ITERATIONS=${{ inputs.max_iterations || 50 }}" >> $GITHUB_ENV
 
       - name: Comment on issue with start message
@@ -119,7 +127,8 @@ jobs:
             --repo ${{ github.repository }} \
             --issue-number ${{ env.ISSUE_NUMBER }} \
             --issue-type ${{ env.ISSUE_TYPE }} \
-            --max-iterations ${{ env.MAX_ITERATIONS }}
+            --max-iterations ${{ env.MAX_ITERATIONS }} \
+            --comment-id ${{ env.COMMENT_ID }}
 
       - name: Check resolution result
         id: check_result
@@ -132,11 +141,11 @@ jobs:
 
       - name: Upload output.jsonl as artifact
         uses: actions/upload-artifact@v4
-        if: always()  # Upload even if the previous steps fail
+        if: always() # Upload even if the previous steps fail
         with:
           name: resolver-output
           path: /tmp/output/output.jsonl
-          retention-days: 30  # Keep the artifact for 30 days
+          retention-days: 30 # Keep the artifact for 30 days
 
       - name: Create draft PR or push branch
         env:

--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -97,14 +97,12 @@ class IssueHandler(IssueHandlerInterface):
             if comment_id:
                 matching_comment = next((comment["body"] for comment in comments if comment["id"] == comment_id), None)
                 if matching_comment:
-                    print("found the comment")
                     return [matching_comment]
             else:
                 all_comments.extend([comment["body"] for comment in comments])
 
             params["page"] += 1
 
-        print("didn't match")
         return all_comments if all_comments else None
     
     def get_converted_issues(self, comment_id: int | None = None) -> list[GithubIssue]:
@@ -128,7 +126,6 @@ class IssueHandler(IssueHandlerInterface):
             
             # Get issue thread comments
             thread_comments = self._get_issue_comments(issue["number"], comment_id=comment_id)
-            print("final thread comments", thread_comments)
             # Convert empty lists to None for optional fields
             issue_details = GithubIssue(
                                 owner=self.owner,

--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -18,7 +18,7 @@ class IssueHandlerInterface(ABC):
     issue_type: ClassVar[str]
     
     @abstractmethod
-    def get_converted_issues(self) -> list[GithubIssue]:
+    def get_converted_issues(self, comment_id: int | None = None) -> list[GithubIssue]:
         """Download issues from GitHub."""
         pass
     
@@ -76,7 +76,7 @@ class IssueHandler(IssueHandlerInterface):
         image_pattern = r'!\[.*?\]\((https?://[^\s)]+)\)'
         return re.findall(image_pattern, issue_body)
 
-    def _get_issue_comments(self, issue_number: int) -> list[str] | None:
+    def _get_issue_comments(self, issue_number: int, comment_id: int | None = None) -> list[str] | None:
         """Download comments for a specific issue from Github."""
         url = f"https://api.github.com/repos/{self.owner}/{self.repo}/issues/{issue_number}/comments"
         headers = {
@@ -94,18 +94,26 @@ class IssueHandler(IssueHandlerInterface):
             if not comments:
                 break
 
-            all_comments.extend([comment["body"] for comment in comments])
+            if comment_id:
+                matching_comment = next((comment["body"] for comment in comments if comment["id"] == comment_id), None)
+                if matching_comment:
+                    print("found the comment")
+                    return [matching_comment]
+            else:
+                all_comments.extend([comment["body"] for comment in comments])
+
             params["page"] += 1
 
+        print("didn't match")
         return all_comments if all_comments else None
     
-    def get_converted_issues(self) -> list[GithubIssue]:
+    def get_converted_issues(self, comment_id: int | None = None) -> list[GithubIssue]:
         """Download issues from Github.
 
         Returns:
             List of Github issues.
         """
-         
+        logger.warning(f"Fetching for comment_id {comment_id}")
         all_issues = self._download_issues_from_github()
         converted_issues = []
         for issue in all_issues:
@@ -119,7 +127,8 @@ class IssueHandler(IssueHandlerInterface):
                 continue
             
             # Get issue thread comments
-            thread_comments = self._get_issue_comments(issue["number"])
+            thread_comments = self._get_issue_comments(issue["number"], comment_id=comment_id)
+            print("final thread comments", thread_comments)
             # Convert empty lists to None for optional fields
             issue_details = GithubIssue(
                                 owner=self.owner,
@@ -132,6 +141,7 @@ class IssueHandler(IssueHandlerInterface):
                             )
                 
             converted_issues.append(issue_details)
+
         return converted_issues
 
     def get_instruction(self, issue: GithubIssue, prompt_template: str, repo_instruction: str | None = None) -> tuple[str, list[str]]:
@@ -332,7 +342,7 @@ class PRHandler(IssueHandler):
 
         return all_comments if all_comments else None
 
-    def get_converted_issues(self) -> list[GithubIssue]:
+    def get_converted_issues(self, comment_id: int | None = None) -> list[GithubIssue]:
         all_issues = self._download_issues_from_github()
         converted_issues = []
         for issue in all_issues:

--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -111,7 +111,6 @@ class IssueHandler(IssueHandlerInterface):
         Returns:
             List of Github issues.
         """
-        logger.warning(f"Fetching for comment_id {comment_id}")
         all_issues = self._download_issues_from_github()
         converted_issues = []
         for issue in all_issues:

--- a/openhands_resolver/resolve_issue.py
+++ b/openhands_resolver/resolve_issue.py
@@ -302,6 +302,7 @@ async def resolve_issue(
     issue_type: str,
     repo_instruction: str | None,
     issue_number: int,
+    comment_id: str | None,
     reset_logger: bool = False,
 ) -> None:
     """Resolve a single github issue.
@@ -322,7 +323,7 @@ async def resolve_issue(
     issue_handler = issue_handler_factory(issue_type, owner, repo, token)
 
     # Load dataset
-    issues: list[GithubIssue] = issue_handler.get_converted_issues()
+    issues: list[GithubIssue] = issue_handler.get_converted_issues(comment_id=comment_id)
     
     # Find the specific issue
     issue = next((i for i in issues if i.number == issue_number), None)
@@ -467,6 +468,13 @@ def main():
         help="Issue number to resolve.",
     )
     parser.add_argument(
+        "--comment-id",
+        type=int,
+        required=False,
+        default=None,
+        help="Resolve a specific comment"
+    )
+    parser.add_argument(
         "--output-dir",
         type=str,
         default="output",
@@ -566,6 +574,7 @@ def main():
             issue_type=issue_type,
             repo_instruction=repo_instruction,
             issue_number=my_args.issue_number,
+            comment_id=my_args.comment_id,
         )
     )
 

--- a/openhands_resolver/resolve_issue.py
+++ b/openhands_resolver/resolve_issue.py
@@ -302,7 +302,7 @@ async def resolve_issue(
     issue_type: str,
     repo_instruction: str | None,
     issue_number: int,
-    comment_id: str | None,
+    comment_id: int | None,
     reset_logger: bool = False,
 ) -> None:
     """Resolve a single github issue.

--- a/openhands_resolver/resolve_issue.py
+++ b/openhands_resolver/resolve_issue.py
@@ -430,6 +430,13 @@ async def resolve_issue(
 def main():
     import argparse
 
+    def int_or_none(value):
+        if value.lower() == 'none':
+            return None
+        else:
+            return int(value)
+
+
     parser = argparse.ArgumentParser(description="Resolve a single issue from Github.")
     parser.add_argument(
         "--repo",
@@ -469,7 +476,7 @@ def main():
     )
     parser.add_argument(
         "--comment-id",
-        type=int,
+        type=int_or_none,
         required=False,
         default=None,
         help="Resolve a specific comment"


### PR DESCRIPTION
This PR partially address issue #232 

# Changes
1. You can now trigger Openhands for Github issues by leaving a new comment on the issue with the macro `@openhands-agent`
2. Openhands only considers the new comment with macro, and the original title/body of the issue as context
3. If you want Openhands to use every comment on an issue as context, the `fix-me` label should be used instead of the macro

# Sample test with macro
[Workflow log
](https://github.com/malhotra5/test-repo/actions/runs/11764052317/job/32768758245)

# Future work
I'm thinking of doing the following work on separate PRs

1. Starting the resolver from comments containing macro on PRs
2. Allowing users to customize the macro that triggers the resolver