### PR TITLE
example needs permissions to not error

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -34,11 +34,6 @@ jobs:
     if: github.event_name == 'workflow_call' || github.event.label.name == 'fix-me' || github.event.label.name == 'fix-me-experimental'
     runs-on: ubuntu-latest
     steps:
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
-
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -34,6 +34,11 @@ jobs:
     if: github.event_name == 'workflow_call' || github.event.label.name == 'fix-me' || github.event.label.name == 'fix-me-experimental'
     runs-on: ubuntu-latest
     steps:
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/examples/openhands-resolver.yml
+++ b/examples/openhands-resolver.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   call-openhands-resolver:
     uses: All-Hands-AI/openhands-resolver/.github/workflows/openhands-resolver.yml@main


### PR DESCRIPTION
If these permissions are not set, then I don't have enough permissions to run the github actions in my organization's repo. I get the following error unless these permissions are set:

`The workflow is not valid. .github/workflows/openhands-resolver.yml (Line: 10, Col: 3): Error calling workflow 'All-Hands-AI/openhands-resolver/.github/workflows/openhands-resolver.yml@main'. The workflow is requesting 'contents: write, issues: write, pull-requests: write', but is only allowed 'contents: read, issues: none, pull-requests: none'.`