### PR TITLE
Add repo instructions option

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -11,6 +11,9 @@ on:
         required: false
         type: string
         default: "@openhands-agent"
+      repo-instruction-file:
+        required: false
+        type: string
     secrets:
       LLM_MODEL:
         required: true
@@ -97,6 +100,7 @@ jobs:
           fi
 
           echo "COMMENT_ID=${{ github.event.comment.id || 'None' }}" >> $GITHUB_ENV
+          echo "MAX_ITERATIONS=${{ inputs.max_iterations || 50 }}" >> $GITHUB_ENV
           echo "MAX_ITERATIONS=${{ inputs.max_iterations || 50 }}" >> $GITHUB_ENV
 
       - name: Comment on issue with start message

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -101,7 +101,7 @@ jobs:
 
           echo "COMMENT_ID=${{ github.event.comment.id || 'None' }}" >> $GITHUB_ENV
           echo "MAX_ITERATIONS=${{ inputs.max_iterations || 50 }}" >> $GITHUB_ENV
-          echo "MAX_ITERATIONS=${{ inputs.max_iterations || 50 }}" >> $GITHUB_ENV
+          echo "REPO_INSTRUCTION_FILE=${{ inputs.repo-instruction-file || '' }}" >> $GITHUB_ENV
 
       - name: Comment on issue with start message
         uses: actions/github-script@v7
@@ -138,7 +138,8 @@ jobs:
             --issue-number ${{ env.ISSUE_NUMBER }} \
             --issue-type ${{ env.ISSUE_TYPE }} \
             --max-iterations ${{ env.MAX_ITERATIONS }} \
-            --comment-id ${{ env.COMMENT_ID }}
+            --comment-id ${{ env.COMMENT_ID }} \
+            --repo-instruction-file ${{ env.REPO_INSTRUCTION_FILE }}
 
       - name: Check resolution result
         id: check_result


### PR DESCRIPTION
This way, users can pass in their own files for additional instructions in the .jinja:

```
{% if repo_instruction %}

Some basic information about this repository:
{{ repo_instruction }}{% endif %}
```