### PR TITLE
Fix issue #321: [Enhancement]: Enabling caching for macro invocations

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -62,7 +62,11 @@ jobs:
           cat requirements.txt
 
       - name: Cache pip dependencies
-        if: github.event.label.name == 'fix-me'
+        if: |
+          github.event.label.name == 'fix-me' ||
+          (github.event_name == 'issue_comment' && 
+           contains(github.event.comment.body, inputs.macro || '@openhands-agent') &&
+           (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER'))
         uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}/lib/python3.12/site-packages/*


### PR DESCRIPTION
This pull request fixes #321.

The issue has been successfully resolved. The AI agent modified the workflow configuration to enable caching in two scenarios:

1. When the `fix-me` label is applied to an issue
2. When a comment is created by an authorized user (OWNER, COLLABORATOR, or MEMBER) containing the macro invocation

This directly addresses the original request to perform the cache action when triggered by comment creation, while maintaining the existing functionality for the `fix-me` label. Since this was a workflow configuration change and not an application code change, no additional tests were required.

This would make an appropriate pull request message to a reviewer:
"Updated the workflow configuration to enable caching when triggered either by the `fix-me` label or by comment creation from authorized users. This enhancement improves performance in both trigger scenarios while maintaining existing security controls by limiting comment triggers to authorized users only. As this is a workflow configuration change, no additional tests were required."

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌