### PR TITLE
[Bug]: Macro innvocations

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -42,8 +42,8 @@ jobs:
       github.event.label.name == 'fix-me' ||
       github.event.label.name == 'fix-me-experimental' ||
       (github.event_name == 'issue_comment' && 
-       startsWith(github.event.comment.body, ${{ inputs.macro || '@openhands-agent' }}) &&
-       (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER'))
+      startsWith(github.event.comment.body, inputs.macro || '@openhands-agent') &&
+      (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -42,7 +42,7 @@ jobs:
       github.event.label.name == 'fix-me' ||
       github.event.label.name == 'fix-me-experimental' ||
       (github.event_name == 'issue_comment' && 
-       startsWith(github.event.comment.body, '${{ inputs.macro || "@openhands-agent" }}') &&
+       startsWith(github.event.comment.body, ${{ inputs.macro || '@openhands-agent' }}) &&
        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER'))
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -42,7 +42,7 @@ jobs:
       github.event.label.name == 'fix-me' ||
       github.event.label.name == 'fix-me-experimental' ||
       (github.event_name == 'issue_comment' && 
-       contains(github.event.comment.body, inputs.macro || '@openhands-agent') &&
+       startsWith(github.event.comment.body, '${{ inputs.macro || "@openhands-agent" }}') &&
        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER'))
     runs-on: ubuntu-latest
     steps:

--- a/examples/openhands-resolver.yml
+++ b/examples/openhands-resolver.yml
@@ -13,17 +13,33 @@ permissions:
   pull-requests: write
   issues: write
 
+env:
+  MACRO: "@openhands-agent"
+  MAX_ITERATIONS: 50
+
 jobs:
-  call-openhands-resolver:
-    uses: All-Hands-AI/openhands-resolver/.github/workflows/openhands-resolver.yml@main
+  get-env:
+    name: Get Environment vars
+    runs-on: ubuntu-latest
     if: |
-      github.event.label.name == 'fix-me' ||
-      (github.event_name == 'issue_comment' && 
-       contains(github.event.comment.body, inputs.macro || '@openhands-agent') &&
-       (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER'))
+      ${{
+        github.event.label.name == 'fix-me' ||
+        (github.event_name == 'issue_comment' && 
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER'))
+      }}
+    outputs:
+      MACRO: ${{ env.MACRO }}
+      MAX_ITERATIONS: ${{ env.MAX_ITERATIONS }}
+    steps:
+      - run: echo "null"
+
+  call-openhands-resolver:
+    needs: [get-env]
+    if: ${{ startsWith(github.event.comment.body, needs.get-env.outputs.MACRO) || github.event.label.name == 'fix-me' }}
+    uses: All-Hands-AI/openhands-resolver/.github/workflows/openhands-resolver.yml@bug/comment-invocation
     with:
-      max_iterations: 50
-      macro: "@openhands-agent"
+      macro: ${{ needs.get-env.outputs.MACRO }}
+      max_iterations: ${{ fromJSON(needs.get-env.outputs.MAX_ITERATIONS) }}
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
       PAT_USERNAME: ${{ secrets.PAT_USERNAME }}

--- a/examples/openhands-resolver.yml
+++ b/examples/openhands-resolver.yml
@@ -13,33 +13,19 @@ permissions:
   pull-requests: write
   issues: write
 
-env:
-  MACRO: "@openhands-agent"
-  MAX_ITERATIONS: 50
-
 jobs:
-  get-env:
-    name: Get Environment vars
-    runs-on: ubuntu-latest
+  call-openhands-resolver:
     if: |
       ${{
         github.event.label.name == 'fix-me' ||
         (github.event_name == 'issue_comment' && 
+        startsWith(github.event.comment.body, vars.OPENHANDS_MACRO || '@openhands-agent') &&
         (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER'))
       }}
-    outputs:
-      MACRO: ${{ env.MACRO }}
-      MAX_ITERATIONS: ${{ env.MAX_ITERATIONS }}
-    steps:
-      - run: echo "null"
-
-  call-openhands-resolver:
-    needs: [get-env]
-    if: ${{ startsWith(github.event.comment.body, needs.get-env.outputs.MACRO) || github.event.label.name == 'fix-me' }}
     uses: All-Hands-AI/openhands-resolver/.github/workflows/openhands-resolver.yml@main
     with:
-      macro: ${{ needs.get-env.outputs.MACRO }}
-      max_iterations: ${{ fromJSON(needs.get-env.outputs.MAX_ITERATIONS) }}
+      macro: ${{ vars.OPENHANDS_MACRO || '@openhands-agent' }}
+      max_iterations: 50
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
       PAT_USERNAME: ${{ secrets.PAT_USERNAME }}

--- a/examples/openhands-resolver.yml
+++ b/examples/openhands-resolver.yml
@@ -36,7 +36,7 @@ jobs:
   call-openhands-resolver:
     needs: [get-env]
     if: ${{ startsWith(github.event.comment.body, needs.get-env.outputs.MACRO) || github.event.label.name == 'fix-me' }}
-    uses: All-Hands-AI/openhands-resolver/.github/workflows/openhands-resolver.yml@bug/comment-invocation
+    uses: All-Hands-AI/openhands-resolver/.github/workflows/openhands-resolver.yml@main
     with:
       macro: ${{ needs.get-env.outputs.MACRO }}
       max_iterations: ${{ fromJSON(needs.get-env.outputs.MAX_ITERATIONS) }}


### PR DESCRIPTION
This address multitude of bugs when implementing custom macro trigger for #232 

- #318: Every comment was triggering the action
- #316: Macro could be invoked by anyone leaving a comment
- Example reusable workflow was not passing custom macro

# Changes

The example workflow now requires the users to set their `ENV` variables at the top of the file. The workflow performs the following - 

1. It checks if the user
    a. has correct permissions
    b. used the `fix-me` label or created a new comment
2. It passes the ENV variables down as outputs for the next job (so that its available at the job conditional)
3. If the first two steps are successful the second job is triggered
4. The second job triggers openhands workflow if a macro, or the `fix-me` label was used 

# Challenges
Currently, every time a comment is created this workflow is triggered. The first job makes the custom macro available to the second job. This is because `ENV` variables or `WITH` parameters are not available at the job conditional. 

A way to get around this is to set a repository variable. It does, however, require more effort from the user. I think its better to do this regardless. Will open a separate PR for this.

