### PR TITLE
[Feat]: Invoking openhands-resolver on PRs using macro

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -47,12 +47,7 @@ jobs:
       github.event.label.name == 'fix-me-experimental' ||
 
       (
-        (github.event_name == 'issue_comment' && 
-        startsWith(github.event.comment.body, inputs.macro || '@openhands-agent') &&
-        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER')
-        ) ||
-        
-        (github.event_name == 'pull_request_review_comment' && 
+        ((github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && 
         startsWith(github.event.comment.body, inputs.macro || '@openhands-agent') &&
         (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER')
         ) ||

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -29,6 +29,10 @@ on:
     types: [labeled]
   issue_comment:
     types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   contents: write
@@ -41,9 +45,23 @@ jobs:
       github.event_name == 'workflow_call' ||
       github.event.label.name == 'fix-me' ||
       github.event.label.name == 'fix-me-experimental' ||
-      (github.event_name == 'issue_comment' && 
-      startsWith(github.event.comment.body, inputs.macro || '@openhands-agent') &&
-      (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER'))
+
+      (
+        (github.event_name == 'issue_comment' && 
+        startsWith(github.event.comment.body, inputs.macro || '@openhands-agent') &&
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER')
+        ) ||
+        
+        (github.event_name == 'pull_request_review_comment' && 
+        startsWith(github.event.comment.body, inputs.macro || '@openhands-agent') &&
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER')
+        ) ||
+        
+        (github.event_name == 'pull_request_review' && 
+        startsWith(github.event.review.body, inputs.macro || '@openhands-agent') &&
+        (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'COLLABORATOR' || github.event.review.author_association == 'MEMBER')
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -88,7 +106,13 @@ jobs:
 
       - name: Set environment variables
         run: |
-          if [ -n "${{ github.event.pull_request.number }}" ]; then
+          if [ -n "${{ github.event.review.body }}" ]; then
+            echo "ISSUE_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+            echo "ISSUE_TYPE=pr" >> $GITHUB_ENV
+          elif [ -n "${{ github.event.issue.pull_request }}" ]; then
+            echo "ISSUE_NUMBER=${{ github.event.issue.number }}" >> $GITHUB_ENV
+            echo "ISSUE_TYPE=pr" >> $GITHUB_ENV
+          elif [ -n "${{ github.event.pull_request.number }}" ]; then
             echo "ISSUE_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
             echo "ISSUE_TYPE=pr" >> $GITHUB_ENV
           else
@@ -96,7 +120,12 @@ jobs:
             echo "ISSUE_TYPE=issue" >> $GITHUB_ENV
           fi
 
-          echo "COMMENT_ID=${{ github.event.comment.id || 'None' }}" >> $GITHUB_ENV
+          if [ -n "${{ github.event.review.body }}" ]; then
+            echo "COMMENT_ID=${{ github.event.review.id || 'None' }}" >> $GITHUB_ENV
+          else
+            echo "COMMENT_ID=${{ github.event.comment.id || 'None' }}" >> $GITHUB_ENV
+          fi
+
           echo "MAX_ITERATIONS=${{ inputs.max_iterations || 50 }}" >> $GITHUB_ENV
 
       - name: Comment on issue with start message

--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -371,11 +371,6 @@ class PRHandler(IssueHandler):
             
             # Get PR thread comments
             thread_comments = self._get_pr_comments(issue["number"], comment_id=comment_id)
-            
-            if comment_id is not None and len(review_comments) == 0 and len(review_threads) == 0 and len(thread_comments) == 0:
-                raise ValueError(f"Comment ID {comment_id} did not have a match")
-
-
             issue_details = GithubIssue(
                                 owner=self.owner,
                                 repo=self.repo,

--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -372,6 +372,10 @@ class PRHandler(IssueHandler):
             # Get PR thread comments
             thread_comments = self._get_pr_comments(issue["number"], comment_id=comment_id)
             
+            if comment_id is not None and len(review_comments) == 0 and len(review_threads) == 0 and len(thread_comments) == 0:
+                raise ValueError(f"Comment ID {comment_id} did not have a match")
+
+
             issue_details = GithubIssue(
                                 owner=self.owner,
                                 repo=self.repo,

--- a/openhands_resolver/resolve_issue.py
+++ b/openhands_resolver/resolve_issue.py
@@ -329,6 +329,19 @@ async def resolve_issue(
     issue = next((i for i in issues if i.number == issue_number), None)
     if not issue:
         raise ValueError(f"Issue {issue_number} not found")
+    
+    if comment_id is not None:
+        if (issue_type == 'pr'
+            and not issue.review_comments
+            and not issue.review_threads 
+            and not issue.thread_comments):
+            raise ValueError(f"Comment ID {comment_id} did not have a match for issue {issue.number}")
+
+        if (issue_type == 'issue'
+            and not issue.thread_comments):
+            raise ValueError(f"Comment ID {comment_id} did not have a match for issue {issue.number}")
+
+    
 
     # TEST METADATA
     model_name = llm_config.model.split("/")[-1]


### PR DESCRIPTION
This PR partially addresses #232 

# Changes
You can now invoke `openhands-resolver` on PRs with a macro! Here's how it works

1. If you're leaving a regular comment, `openhands-resolver` only considers the PR, linked issues, and the comment you've left
2. If you're leaving a review comment, `openhands-resolver` only considers the PR, linked issues, and the review comment you've left
3. If you're leaving a comment on a review thread, `openhands-resolver` only considers the PR, linked issues, and the ENTIRE thread where the comment was left

# Future PR
Will check all comment bodies and PR bodies for references to issues. If such references exist, will pull the issues' bodies into the resolver as context as well.