### PR TITLE
[Bug]: Check if file already exists in localization details

### DIFF
--- a/openhands_resolver/issue_definitions.py
+++ b/openhands_resolver/issue_definitions.py
@@ -309,7 +309,7 @@ class PRHandler(IssueHandler):
                         message += review_thread["body"] + "\n"  # Add each thread in a new line
                     
                     file = review_thread.get("path")
-                    if file:
+                    if file and file not in files:
                         files.append(file)
 
                 if comment_id is None or thread_contains_comment_id:

--- a/tests/test_issue_handler.py
+++ b/tests/test_issue_handler.py
@@ -384,7 +384,7 @@ def test_pr_handler_get_converted_issues_with_specific_review_thread_comment():
                                     'comments': {
                                         'nodes': [
                                             {'fullDatabaseId': specific_comment_id, 'body': 'Specific review comment', 'path': 'file1.txt'},
-                                            {'fullDatabaseId': 456, 'body': 'Another review comment', 'path': 'file2.txt'}
+                                            {'fullDatabaseId': 456, 'body': 'Another review comment', 'path': 'file1.txt'}
                                         ]
                                     }
                                 }
@@ -427,7 +427,8 @@ def test_pr_handler_get_converted_issues_with_specific_review_thread_comment():
             assert len(prs[0].review_threads) == 1
             assert isinstance(prs[0].review_threads[0], ReviewThread)
             assert prs[0].review_threads[0].comment == "Specific review comment\n---\nlatest feedback:\nAnother review comment\n"
-            
+            assert prs[0].review_threads[0].files == ["file1.txt"]
+
             # Verify other fields are set correctly
             assert prs[0].number == 1
             assert prs[0].title == 'Test PR'


### PR DESCRIPTION
This bug was introduced in #217 when addressing #189

# Bug description
When an inline review comment is left, we provide resolver details on which file the review comment applies to. If multiple comments are left for the same file, resolver receives duplicate instances in `review_thread_files` details. Example attached below

```
# Issues addressed 
[
    "![image](https://github.com/user-attachments/assets/e411289b-217b-44d4-8b5a-5eba2e447b20)\r\n"
]

# Review comments
None

# Review threads
[
    "@test-repo-helper change Openhands resovler to lowercase inline code\n@test-repo-helper test another comment underneath the same thread\n---\nlatest feedback:\nthis is a thread comment\n"
]

# Review thread files
[
    "README.md",
    "README.md",
    "README.md"
]
```

# Summary
Don't add another file instance if it already exists in the context