### PR TITLE
[Feat]: Enable caching when using macro on PRs

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -75,7 +75,11 @@ jobs:
           cat requirements.txt
 
       - name: Cache pip dependencies
-        if: github.event.label.name == 'fix-me' || github.event_name == 'issue_comment'
+        if: |
+          github.event.label.name == 'fix-me' || 
+          github.event_name == 'issue_comment' || 
+          github.event_name == 'pull_request_review_comment' || 
+          github.event_name == 'pull_request_review'
         uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}/lib/python3.12/site-packages/*


### PR DESCRIPTION
This addresses one part of #232 

Caching of pip dependencies has been enabled when `openhands-resolver` is invoked using issue labels or a macro on issue comments. 
This enables caching for when the macro is used on PRs as well. 