### PR TITLE
Fix issue #329: [bug] pip dependency conflict error: pytest version conflict with openhands-resolver

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4686,6 +4686,23 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -6962,4 +6979,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "1948f7655ba6d3360cf491d2008ab985c28a25d1f565f1e964cf5b0b611cf10d"
+content-hash = "b7bb7dcea41cc231b0487bd74ae24b73e017bf702cf99e544cc7251c492e17f2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ python = "^3.12"
 openhands-ai = ">=0.13.1,<0.14.0"
 
 pandas = "^2.2.3"
-pytest = "^8.3.3"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "*"
@@ -31,7 +30,8 @@ pre-commit = "*"
 types-toml = "*"
 
 [tool.poetry.group.test.dependencies]
-pytest = "*"
+pytest = ">=6.2.5,<9.0.0"
+pytest-mock = ">=3.14.0"
 pytest-asyncio = "*"
 
 


### PR DESCRIPTION
Fixes #329, basically by moving pytest to test dependencies.