### PR TITLE
Push and comment even if previous steps fail

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -183,6 +183,7 @@ jobs:
           retention-days: 30 # Keep the artifact for 30 days
 
       - name: Create draft PR or push branch
+        if: always() # Push branch even if the previous steps fail
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           LLM_MODEL: ${{ secrets.LLM_MODEL }}
@@ -205,6 +206,7 @@ jobs:
 
       - name: Comment on issue
         uses: actions/github-script@v7
+        if: always() # Comment even if the previous steps fail
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
The resolve_issue frequently crashes for me due to a variety of issues, but i have no visibility into what the openhands-resolver did because it never pushed anything even though it ran for 40 steps and made hundreds of lines of change