### PR TITLE
Fix issue #345: Add warnings for migration

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -138,7 +138,7 @@ jobs:
               issue_number: ${{ env.ISSUE_NUMBER }},
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `OpenHands started fixing the ${issueType}! You can monitor the progress [here](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`
+              body: `OpenHands started fixing the ${issueType}! You can monitor the progress [here](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).\n\n> ALERT: message from your friendly neighborhood code agent -> this is an old version of the OpenHands github resolver. It has been moved to https://github.com/All-Hands-AI/OpenHands/tree/main/openhands/resolver`
             });
 
       - name: Install dependencies
@@ -244,27 +244,27 @@ jobs:
                 issue_number: issueNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: `The workflow to fix this issue encountered an error. Openhands failed to create any code changes.`
+                body: `The workflow to fix this issue encountered an error. Openhands failed to create any code changes.\n\n> ALERT: message from your friendly neighborhood code agent -> this is an old version of the OpenHands github resolver. It has been moved to https://github.com/All-Hands-AI/OpenHands/tree/main/openhands/resolver`
               });
             } else if (success && prNumber) {
               github.rest.issues.createComment({
                 issue_number: issueNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: `A potential fix has been generated and a draft PR #${prNumber} has been created. Please review the changes.`
+                body: `A potential fix has been generated and a draft PR #${prNumber} has been created. Please review the changes.\n\n> ALERT: message from your friendly neighborhood code agent -> this is an old version of the OpenHands github resolver. It has been moved to https://github.com/All-Hands-AI/OpenHands/tree/main/openhands/resolver`
               });
             } else if (!success && branchName) {
               github.rest.issues.createComment({
                 issue_number: issueNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: `An attempt was made to automatically fix this issue, but it was unsuccessful. A branch named '${branchName}' has been created with the attempted changes. You can view the branch [here](https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${branchName}). Manual intervention may be required.`
+                body: `An attempt was made to automatically fix this issue, but it was unsuccessful. A branch named '${branchName}' has been created with the attempted changes. You can view the branch [here](https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${branchName}). Manual intervention may be required.\n\n> ALERT: message from your friendly neighborhood code agent -> this is an old version of the OpenHands github resolver. It has been moved to https://github.com/All-Hands-AI/OpenHands/tree/main/openhands/resolver`
               });
             } else {
               github.rest.issues.createComment({
                 issue_number: issueNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: `The workflow to fix this issue encountered an error. Please check the workflow logs for more information.`
+                body: `The workflow to fix this issue encountered an error. Please check the workflow logs for more information.\n\n> ALERT: message from your friendly neighborhood code agent -> this is an old version of the OpenHands github resolver. It has been moved to https://github.com/All-Hands-AI/OpenHands/tree/main/openhands/resolver`
               });
             }

--- a/examples/openhands-resolver.yml
+++ b/examples/openhands-resolver.yml
@@ -1,5 +1,7 @@
 name: Resolve Issue with OpenHands
 
+# ALERT: message from your friendly neighborhood code agent -> this is an old version of the OpenHands github resolver. It has been moved to https://github.com/All-Hands-AI/OpenHands/tree/main/openhands/resolver
+
 on:
   issues:
     types: [labeled]

--- a/openhands_resolver/__init__.py
+++ b/openhands_resolver/__init__.py
@@ -1,1 +1,11 @@
 __version__ = "0.3.1"
+
+import warnings
+
+warnings.warn(
+    "\nDEPRECATION WARNING: This is an old version of the OpenHands resolver. "
+    "It has been moved to https://github.com/All-Hands-AI/OpenHands/tree/main/openhands/resolver\n"
+    "Please update your dependencies to use the new version.",
+    DeprecationWarning,
+    stacklevel=2
+)


### PR DESCRIPTION
This pull request fixes #345.

The issue has been successfully resolved as both requested changes were implemented:

1. Warning statements were added to `openhands-resolver` using Python's `warnings` module with `DeprecationWarning`, which will be shown when users import/run the package. This satisfies the first requirement to notify users about the refactor.

2. The warning message was added to the GitHub Actions workflow file (`examples/openhands-resolver.yml`), which will be visible to users who are using the resolver through GitHub Actions. This satisfies the second requirement of notifying users who might miss the runtime warning.

The changes are non-functional additions that simply provide user notifications about the deprecation, so no additional testing is required. The implementation addresses both key requirements from the original issue while maintaining the existing functionality of the code.

The PR can be described as:
"Added deprecation warnings to notify users about the migration of openhands-resolver to OpenHands. Implemented warnings both in the package initialization and GitHub Actions workflow file to ensure all users are informed about the change."

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌